### PR TITLE
chore: replace obsolete rs-proxy address

### DIFF
--- a/default-cluster-templates/baseline.json
+++ b/default-cluster-templates/baseline.json
@@ -1,6 +1,6 @@
 {
   "name": "baseline",
-  "version": "v2.0.1",
+  "version": "v2.0.2",
   "kubernetesVersion": "v1.30.10+rke2r1",
   "description": "Baseline Cluster Template",
   "controlplaneprovidertype": "rke2",
@@ -39,7 +39,7 @@
           ],
           "privateRegistriesConfig": {
             "mirrors": {
-              "rs-proxy.rs-proxy.svc.cluster.local:8443": {
+              "edge-node-release-proxy.local": {
                 "endpoint": [
                   "https://localhost.internal:9443"
                 ]

--- a/default-cluster-templates/privileged.json
+++ b/default-cluster-templates/privileged.json
@@ -1,6 +1,6 @@
 {
   "name": "privileged",
-  "version": "v2.0.1",
+  "version": "v2.0.2",
   "kubernetesVersion": "v1.30.10+rke2r1",
   "description": "Privileged Cluster Template",
   "controlplaneprovidertype": "rke2",
@@ -39,7 +39,7 @@
           ],
           "privateRegistriesConfig": {
             "mirrors": {
-              "rs-proxy.rs-proxy.svc.cluster.local:8443": {
+              "edge-node-release-proxy.local": {
                 "endpoint": [
                   "https://localhost.internal:9443"
                 ]

--- a/default-cluster-templates/restricted.json
+++ b/default-cluster-templates/restricted.json
@@ -1,6 +1,6 @@
 {
   "name": "restricted",
-  "version": "v2.0.1",
+  "version": "v2.0.2",
   "kubernetesVersion": "v1.30.10+rke2r1",
   "description": "Restricted Cluster Template",
   "controlplaneprovidertype": "rke2",
@@ -39,7 +39,7 @@
           ],
           "privateRegistriesConfig": {
             "mirrors": {
-              "rs-proxy.rs-proxy.svc.cluster.local:8443": {
+              "edge-node-release-proxy.local": {
                 "endpoint": [
                   "https://localhost.internal:9443"
                 ]


### PR DESCRIPTION
The rs-proxy address no longer matches the address that was used on the orchestrator, and there was never a reason to keep them in sync in the first place. This patch replaces the obsolete address with a new one, `edge-node-release-proxy.local` which should both be self-explanatory to those who use it, and avoids any coincidental resemblance to the rs-proxy address used on the orchestrator.
