### PR TITLE
Prep for buildall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,11 +99,6 @@ DISABLE_AUTH ?= true
 # Should be true for CO subsystem integration tests if inventory is not deployed
 DISABLE_INV ?= true
 
-# Setting SHELL to bash allows bash commands to be executed by recipes.
-# Options are set to exit when a recipe line exits non-zero or a piped command fails.
-SHELL = /usr/bin/env bash -o pipefail
-.SHELLFLAGS = -ec
-
 .PHONY: all
 all: help
 


### PR DESCRIPTION
supports: open-edge-platform/edge-manageability-framework#8

clean up yamllint config which uses an unsupported regextype method which was throwing errors