### PR TITLE
refactor: simplify ClusterTemplate controller tests with DescribeTable

### DIFF
--- a/internal/controller/clustertemplate_controller_test.go
+++ b/internal/controller/clustertemplate_controller_test.go
@@ -25,32 +25,32 @@ import (
 	clusterv1alpha1 "github.com/open-edge-platform/cluster-manager/v2/api/v1alpha1"
 )
 
-var _ = Describe("ClusterTemplate Controller for Kubeadm CP and Docker Infra", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+var _ = Describe("ClusterTemplate Controller", func() {
+	const resourceName = "test-resource"
+	ctx := context.Background()
 
-		ctx := context.Background()
+	typeNamespacedName := types.NamespacedName{
+		Name:      resourceName,
+		Namespace: "default",
+	}
 
-		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		clustertemplate := &clusterv1alpha1.ClusterTemplate{}
+	DescribeTable("Reconcile ClusterTemplate resources",
+		func(controlPlaneProviderType, infraProviderType, kubernetesVersion, clusterConfiguration string, validateResources func()) {
+			clustertemplate := &clusterv1alpha1.ClusterTemplate{}
 
-		BeforeEach(func() {
 			By("creating the custom resource for the Kind ClusterTemplate")
 			err := k8sClient.Get(ctx, typeNamespacedName, clustertemplate)
 			if err != nil && errors.IsNotFound(err) {
 				resource := &clusterv1alpha1.ClusterTemplate{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
+						Name:      typeNamespacedName.Name,
+						Namespace: typeNamespacedName.Namespace,
 					},
 					Spec: clusterv1alpha1.ClusterTemplateSpec{
-						ControlPlaneProviderType: "kubeadm",
-						InfraProviderType:        "docker",
-						KubernetesVersion:        "v1.30.6",
-						ClusterConfiguration:     "{\"apiVersion\":\"controlplane.cluster.x-k8s.io/v1beta1\",\"kind\":\"KubeadmControlPlaneTemplate\",\"metadata\":{\"name\":\"kubeadm-control-plane-template-v0.1.0\"},\"spec\":{\"template\":{\"spec\":{\"kubeadmConfigSpec\":{\"clusterConfiguration\":{\"apiServer\":{\"certSANs\":[\"localhost\",\"127.0.0.1\",\"0.0.0.0\",\"host.docker.internal\"]}},\"initConfiguration\":{\"nodeRegistration\":{}},\"joinConfiguration\":{\"nodeRegistration\":{}},\"postKubeadmCommands\":[\"kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/calico.yaml\"]}}}}}",
+						ControlPlaneProviderType: controlPlaneProviderType,
+						InfraProviderType:        infraProviderType,
+						KubernetesVersion:        kubernetesVersion,
+						ClusterConfiguration:     clusterConfiguration,
 						ClusterNetwork: clusterv1alpha1.ClusterNetwork{
 							Services: &clusterv1alpha1.NetworkRanges{
 								CIDRBlocks: []string{"10.43.0.0/16"},
@@ -66,11 +66,33 @@ var _ = Describe("ClusterTemplate Controller for Kubeadm CP and Docker Infra", f
 				}
 				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 			}
-		})
 
-		AfterEach(func() {
+			By("Reconciling the created resource")
+			controllerReconciler := &ClusterTemplateReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, typeNamespacedName, clustertemplate)).To(Succeed())
+			Expect(clustertemplate.Status.Ready).To(BeTrue())
+
+			// Different combinations of control-plane and infrastructure provider types
+			// result in the creation of various resources. The validation function
+			// must handle different struct types, which is why this logic was
+			// moved to a separate function.
+			validateResources()
+
+			By("validating the ClusterClass is created")
+			err = k8sClient.Get(ctx, typeNamespacedName, &capiv1beta1.ClusterClass{})
+			Expect(err).NotTo(HaveOccurred())
+
 			resource := &clusterv1alpha1.ClusterTemplate{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			err = k8sClient.Get(ctx, typeNamespacedName, resource)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("validating the ClusterClass Reference is set")
@@ -80,286 +102,89 @@ var _ = Describe("ClusterTemplate Controller for Kubeadm CP and Docker Infra", f
 			Expect(controllerutil.ContainsFinalizer(resource, clusterv1alpha1.ClusterTemplateFinalizer)).To(BeTrue())
 
 			By("Cleanup the specific resource instance ClusterTemplate")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, clustertemplate)).To(Succeed())
 
 			By("Reconciling the deleted resource")
-			controllerReconciler := &ClusterTemplateReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("validating the finalizer is removed")
-			err = k8sClient.Get(ctx, typeNamespacedName, resource)
+			err = k8sClient.Get(ctx, typeNamespacedName, clustertemplate)
 			if err == nil {
-				Expect(controllerutil.ContainsFinalizer(resource, clusterv1alpha1.ClusterTemplateFinalizer)).To(BeFalse())
+				Expect(controllerutil.ContainsFinalizer(clustertemplate, clusterv1alpha1.ClusterTemplateFinalizer)).To(BeFalse())
 			}
-		})
+		},
 
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &ClusterTemplateReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
+		Entry("for Kubeadm CP and Docker Infra",
+			"kubeadm", "docker", "v1.30.6",
+			"{\"apiVersion\":\"controlplane.cluster.x-k8s.io/v1beta1\",\"kind\":\"KubeadmControlPlaneTemplate\",\"metadata\":{\"name\":\"kubeadm-control-plane-template-v0.1.0\"},\"spec\":{\"template\":{\"spec\":{\"kubeadmConfigSpec\":{\"clusterConfiguration\":{\"apiServer\":{\"certSANs\":[\"localhost\",\"127.0.0.1\",\"0.0.0.0\",\"host.docker.internal\"]}},\"initConfiguration\":{\"nodeRegistration\":{}},\"joinConfiguration\":{\"nodeRegistration\":{}},\"postKubeadmCommands\":[\"kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/calico.yaml\"]}}}}}",
+			func() {
+				By("validating the DockerMachineTemplate is created")
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      fmt.Sprintf("%s-controlplane", typeNamespacedName.Name),
+					Namespace: typeNamespacedName.Namespace,
+				}, &dockerv1beta1.DockerMachineTemplate{})
+				Expect(err).NotTo(HaveOccurred())
 
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
+				By("validating the DockerClusterTemplate is created")
+				err = k8sClient.Get(ctx, typeNamespacedName, &dockerv1beta1.DockerClusterTemplate{})
+				Expect(err).NotTo(HaveOccurred())
 
-			Expect(k8sClient.Get(ctx, typeNamespacedName, clustertemplate)).To(Succeed())
-			Expect(clustertemplate.Status.Ready).To(BeTrue())
+				By("validating the KubeadmControlPlaneTemplate is created")
+				err = k8sClient.Get(ctx, typeNamespacedName, &kubeadmcpv1beta1.KubeadmControlPlaneTemplate{})
+				Expect(err).NotTo(HaveOccurred())
+			},
+		),
 
-			By("validating the DockerMachineTemplate is created")
-			err = k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf("%s-controlplane", typeNamespacedName.Name),
-				Namespace: typeNamespacedName.Namespace,
-			}, &dockerv1beta1.DockerMachineTemplate{})
-			Expect(err).NotTo(HaveOccurred())
+		Entry("for RKE2 CP and Docker Infra",
+			"rke2", "docker", "v1.30.6+rke2r1",
+			"{\"kind\":\"RKE2ControlPlaneTemplate\",\"apiVersion\":\"controlplane.cluster.x-k8s.io/v1beta1\",\"spec\":{\"template\":{\"spec\":{\"serverConfig\":{\"cni\":\"calico\",\"disableComponents\":{\"kubernetesComponents\":[\"cloudController\"]}},\"nodeDrainTimeout\":\"2m\",\"rolloutStrategy\":{\"type\":\"RollingUpdate\",\"rollingUpdate\":{\"maxSurge\":1}}}}}}",
+			func() {
+				By("validating the DockerMachineTemplate is created")
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      fmt.Sprintf("%s-controlplane", typeNamespacedName.Name),
+					Namespace: typeNamespacedName.Namespace,
+				}, &dockerv1beta1.DockerMachineTemplate{})
+				Expect(err).NotTo(HaveOccurred())
 
-			By("validating the DockerClusterTemplate is created")
-			err = k8sClient.Get(ctx, typeNamespacedName, &dockerv1beta1.DockerClusterTemplate{})
-			Expect(err).NotTo(HaveOccurred())
+				By("validating the Prerequisites ConfigMap is created")
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      fmt.Sprintf("%s-rke2-class-lb-config", typeNamespacedName.Name),
+					Namespace: typeNamespacedName.Namespace,
+				}, &corev1.ConfigMap{})
+				Expect(err).NotTo(HaveOccurred())
 
-			By("validating the KubeadmControlPlaneTemplate is created")
-			err = k8sClient.Get(ctx, typeNamespacedName, &kubeadmcpv1beta1.KubeadmControlPlaneTemplate{})
-			Expect(err).NotTo(HaveOccurred())
+				By("validating the DockerClusterTemplate is created")
+				err = k8sClient.Get(ctx, typeNamespacedName, &dockerv1beta1.DockerClusterTemplate{})
+				Expect(err).NotTo(HaveOccurred())
 
-			By("validating the ClusterClass is created")
-			err = k8sClient.Get(ctx, typeNamespacedName, &capiv1beta1.ClusterClass{})
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-})
+				By("validating the RKE2ControlPlaneTemplate is created")
+				err = k8sClient.Get(ctx, typeNamespacedName, &rke2cpv1beta1.RKE2ControlPlaneTemplate{})
+				Expect(err).NotTo(HaveOccurred())
+			},
+		),
 
-var _ = Describe("ClusterTemplate Controller for RKE2 CP and Docker Infra", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+		Entry("for RKE2 CP and Intel Infra",
+			"rke2", "intel", "v1.30.6+rke2r1",
+			"{\"kind\":\"RKE2ControlPlaneTemplate\",\"apiVersion\":\"controlplane.cluster.x-k8s.io/v1beta1\",\"spec\":{\"template\":{\"spec\":{\"serverConfig\":{\"cni\":\"calico\",\"disableComponents\":{\"kubernetesComponents\":[\"cloudController\"]}},\"nodeDrainTimeout\":\"2m\",\"rolloutStrategy\":{\"type\":\"RollingUpdate\",\"rollingUpdate\":{\"maxSurge\":1}}}}}}",
+			func() {
+				By("validating the IntelMachineTemplate is created")
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      fmt.Sprintf("%s-controlplane", typeNamespacedName.Name),
+					Namespace: typeNamespacedName.Namespace,
+				}, &intelv1alpha1.IntelMachineTemplate{})
+				Expect(err).NotTo(HaveOccurred())
 
-		ctx := context.Background()
+				By("validating the IntelClusterTemplate is created")
+				err = k8sClient.Get(ctx, typeNamespacedName, &intelv1alpha1.IntelClusterTemplate{})
+				Expect(err).NotTo(HaveOccurred())
 
-		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		clustertemplate := &clusterv1alpha1.ClusterTemplate{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind ClusterTemplate")
-			err := k8sClient.Get(ctx, typeNamespacedName, clustertemplate)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &clusterv1alpha1.ClusterTemplate{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
-					},
-					Spec: clusterv1alpha1.ClusterTemplateSpec{
-						ControlPlaneProviderType: "rke2",
-						InfraProviderType:        "docker",
-						KubernetesVersion:        "v1.30.6+rke2r1",
-						ClusterConfiguration:     "{\"kind\":\"RKE2ControlPlaneTemplate\",\"apiVersion\":\"controlplane.cluster.x-k8s.io/v1beta1\",\"spec\":{\"template\":{\"spec\":{\"serverConfig\":{\"cni\":\"calico\",\"disableComponents\":{\"kubernetesComponents\":[\"cloudController\"]}},\"nodeDrainTimeout\":\"2m\",\"rolloutStrategy\":{\"type\":\"RollingUpdate\",\"rollingUpdate\":{\"maxSurge\":1}}}}}}",
-						ClusterNetwork: clusterv1alpha1.ClusterNetwork{
-							Services: &clusterv1alpha1.NetworkRanges{
-								CIDRBlocks: []string{"10.43.0.0/16"},
-							},
-							Pods: &clusterv1alpha1.NetworkRanges{
-								CIDRBlocks: []string{"10.42.0.0/16"},
-							},
-						},
-						ClusterLabels: map[string]string{
-							"default-extension": "privileged",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &clusterv1alpha1.ClusterTemplate{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating the finalizer is present")
-			Expect(controllerutil.ContainsFinalizer(resource, clusterv1alpha1.ClusterTemplateFinalizer)).To(BeTrue())
-
-			By("Cleanup the specific resource instance ClusterTemplate")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Reconciling the deleted resource")
-			controllerReconciler := &ClusterTemplateReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-
-			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating the finalizer is removed")
-			err = k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				Expect(controllerutil.ContainsFinalizer(resource, clusterv1alpha1.ClusterTemplateFinalizer)).To(BeFalse())
-			}
-		})
-
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &ClusterTemplateReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(k8sClient.Get(ctx, typeNamespacedName, clustertemplate)).To(Succeed())
-			Expect(clustertemplate.Status.Ready).To(BeTrue())
-
-			By("validating the DockerMachineTemplate is created")
-			err = k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf("%s-controlplane", typeNamespacedName.Name),
-				Namespace: typeNamespacedName.Namespace,
-			}, &dockerv1beta1.DockerMachineTemplate{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating the Prerequisites ConfigMap is created")
-			err = k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf("%s-rke2-class-lb-config", typeNamespacedName.Name),
-				Namespace: typeNamespacedName.Namespace,
-			}, &corev1.ConfigMap{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating the DockerClusterTemplate is created")
-			err = k8sClient.Get(ctx, typeNamespacedName, &dockerv1beta1.DockerClusterTemplate{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating the RKE2ControlPlaneTemplate is created")
-			err = k8sClient.Get(ctx, typeNamespacedName, &rke2cpv1beta1.RKE2ControlPlaneTemplate{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating the ClusterClass is created")
-			err = k8sClient.Get(ctx, typeNamespacedName, &capiv1beta1.ClusterClass{})
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-})
-
-var _ = Describe("ClusterTemplate Controller for RKE2 CP and Intel Infra", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
-
-		ctx := context.Background()
-
-		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		clustertemplate := &clusterv1alpha1.ClusterTemplate{}
-
-		BeforeEach(func() {
-			By("creating the custom resource for the Kind ClusterTemplate")
-			err := k8sClient.Get(ctx, typeNamespacedName, clustertemplate)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &clusterv1alpha1.ClusterTemplate{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
-					},
-					Spec: clusterv1alpha1.ClusterTemplateSpec{
-						ControlPlaneProviderType: "rke2",
-						InfraProviderType:        "intel",
-						KubernetesVersion:        "v1.30.6+rke2r1",
-						ClusterConfiguration:     "{\"kind\":\"RKE2ControlPlaneTemplate\",\"apiVersion\":\"controlplane.cluster.x-k8s.io/v1beta1\",\"spec\":{\"template\":{\"spec\":{\"serverConfig\":{\"cni\":\"calico\",\"disableComponents\":{\"kubernetesComponents\":[\"cloudController\"]}},\"nodeDrainTimeout\":\"2m\",\"rolloutStrategy\":{\"type\":\"RollingUpdate\",\"rollingUpdate\":{\"maxSurge\":1}}}}}}",
-						ClusterNetwork: clusterv1alpha1.ClusterNetwork{
-							Services: &clusterv1alpha1.NetworkRanges{
-								CIDRBlocks: []string{"10.43.0.0/16"},
-							},
-							Pods: &clusterv1alpha1.NetworkRanges{
-								CIDRBlocks: []string{"10.42.0.0/16"},
-							},
-						},
-						ClusterLabels: map[string]string{
-							"default-extension": "privileged",
-						},
-					},
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
-			}
-		})
-
-		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &clusterv1alpha1.ClusterTemplate{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating the finalizer is present")
-			Expect(controllerutil.ContainsFinalizer(resource, clusterv1alpha1.ClusterTemplateFinalizer)).To(BeTrue())
-
-			By("Cleanup the specific resource instance ClusterTemplate")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
-
-			By("Reconciling the deleted resource")
-			controllerReconciler := &ClusterTemplateReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-
-			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating the finalizer is removed")
-			err = k8sClient.Get(ctx, typeNamespacedName, resource)
-			if err == nil {
-				Expect(controllerutil.ContainsFinalizer(resource, clusterv1alpha1.ClusterTemplateFinalizer)).To(BeFalse())
-			}
-		})
-
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
-			controllerReconciler := &ClusterTemplateReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
-			}
-
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(k8sClient.Get(ctx, typeNamespacedName, clustertemplate)).To(Succeed())
-			Expect(clustertemplate.Status.Ready).To(BeTrue())
-
-			By("validating the IntelMachineTemplate is created")
-			err = k8sClient.Get(ctx, types.NamespacedName{
-				Name:      fmt.Sprintf("%s-controlplane", typeNamespacedName.Name),
-				Namespace: typeNamespacedName.Namespace,
-			}, &intelv1alpha1.IntelMachineTemplate{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating the IntelClusterTemplate is created")
-			err = k8sClient.Get(ctx, typeNamespacedName, &intelv1alpha1.IntelClusterTemplate{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating the RKE2ControlPlaneTemplate is created")
-			err = k8sClient.Get(ctx, typeNamespacedName, &rke2cpv1beta1.RKE2ControlPlaneTemplate{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By("validating the ClusterClass is created")
-			err = k8sClient.Get(ctx, typeNamespacedName, &capiv1beta1.ClusterClass{})
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
+				By("validating the RKE2ControlPlaneTemplate is created")
+				err = k8sClient.Get(ctx, typeNamespacedName, &rke2cpv1beta1.RKE2ControlPlaneTemplate{})
+				Expect(err).NotTo(HaveOccurred())
+			},
+		),
+	)
 })


### PR DESCRIPTION
### Description

While implementing 3 types of providers (kubeadmdocker rke2docker rke2intel) tests for controller's reconcile loop were copy-pasted and tweaked in few places.

With more providers in mind - TDD approach was introduced.

Each provider creates different set of object in its runtime - that's why each scenario has different `validateResources()` function

### Any Newly Introduced Dependencies
Ginko's DescribeTable

### How Has This Been Tested?

`make test`

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code