### PR TITLE
fix: Deletion of cluster labels don't work

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -261,7 +261,7 @@ func (cli *Client) CreateTemplateLabels(ctx context.Context, namespace string, t
 // createLabels creates new labels on the resource object in the given namespace
 // It retries on transient "the object has been modified" error, which is expected when the cluster object was updated by another process after we fetched it
 // It returns an error if the operation fails after all retries
-func createLabels(ctx context.Context, cli *Client, namespace string, resourceSchema schema.GroupVersionResource, resourceName string, newLabels map[string]string) error {
+func createLabels(ctx context.Context, cli *Client, namespace string, resourceSchema schema.GroupVersionResource, resourceName string, newUserLabels map[string]string) error {
 	transientError := func(err error) bool {
 		tryAgainErrPattern := "the object has been modified; please apply your changes to the latest version and try again"
 		return strings.Contains(err.Error(), tryAgainErrPattern)
@@ -272,7 +272,12 @@ func createLabels(ctx context.Context, cli *Client, namespace string, resourceSc
 		if err != nil {
 			return backoff.Permanent(err)
 		}
-		resource.SetLabels(labels.Merge(resource.GetLabels(), newLabels))
+		allLabels := resource.GetLabels()
+		previousUserLabels := labels.Filter(allLabels)
+		for key := range previousUserLabels {
+			delete(allLabels, key)
+		}
+		resource.SetLabels(labels.Merge(allLabels, newUserLabels))
 		if _, err = cli.Dyn.Resource(resourceSchema).Namespace(namespace).Update(ctx, resource, metav1.UpdateOptions{}); err != nil {
 			if transientError(err) {
 				return err // retry on transient error


### PR DESCRIPTION
### Description

When a user removes labels through the UI, the UI sends a PUT request containing a list of labels, excluding the ones that were deleted. The cluster manager then merges the existing labels with this new list. However, it fails to verify if the new list is missing any user labels that are already set, resulting in the labels not being removed.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code