### PR TITLE
fix: do not render labels when it is empty

### DIFF
--- a/deployment/charts/cluster-manager/templates/metrics-service.yaml
+++ b/deployment/charts/cluster-manager/templates/metrics-service.yaml
@@ -7,8 +7,10 @@ kind: ServiceMonitor
 metadata:
   name: cluster-manager-metrics
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.metrics.serviceMonitor.labels }}
   labels:
     {{- toYaml .Values.metrics.serviceMonitor.labels | indent 4 }}
+  {{- end }}
 spec:
   endpoints:
   - port: metrics


### PR DESCRIPTION
### Description

I noticed that Argo CD shows `cluster-manager` app as `OutOfSync` when deploying the latest EMF main branch.
Looks like it is trying to apply an empty label and K8s doesn't take it.

![2025-05-08-16-32-52](https://github.com/user-attachments/assets/2117dc42-64ec-4d04-96a0-bbc08e876565)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Yet to be done

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code