### PR TITLE
feat: grafana dashboard

### DIFF
--- a/deployment/charts/cluster-manager/files/dashboards/dashboard.json
+++ b/deployment/charts/cluster-manager/files/dashboards/dashboard.json
@@ -71,7 +71,8 @@
                   "value": 80
                 }
               ]
-            }
+            },
+            "unit": "requests"
           },
           "overrides": []
         },
@@ -87,7 +88,7 @@
             "calcs": [],
             "displayMode": "list",
             "placement": "bottom",
-            "showLegend": true
+            "showLegend": false
           },
           "tooltip": {
             "mode": "single",
@@ -202,6 +203,6 @@
     "timezone": "browser",
     "title": "Cluster Orch - Cluster Manager",
     "uid": "belcotnnxolj4d",
-    "version": 3,
+    "version": 4,
     "weekStart": ""
 }

--- a/deployment/charts/cluster-manager/files/dashboards/dashboard.json
+++ b/deployment/charts/cluster-manager/files/dashboards/dashboard.json
@@ -1,4 +1,4 @@
-{
+  {
     "annotations": {
       "list": [
         {
@@ -17,23 +17,10 @@
     },
     "editable": true,
     "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": 17,
+    "graphTooltip": 1,
+    "id": 24,
     "links": [],
     "panels": [
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "id": 2,
-        "panels": [],
-        "title": "Cluster Manager",
-        "type": "row"
-      },
       {
         "datasource": {
           "type": "prometheus",
@@ -42,21 +29,19 @@
         "fieldConfig": {
           "defaults": {
             "color": {
-              "mode": "palette-classic"
+              "fixedColor": "blue",
+              "mode": "fixed"
             },
             "custom": {
-              "fillOpacity": 80,
-              "gradientMode": "none",
+              "fillOpacity": 70,
               "hideFrom": {
                 "legend": false,
                 "tooltip": false,
                 "viz": false
               },
-              "lineWidth": 1,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              }
+              "insertNulls": false,
+              "lineWidth": 0,
+              "spanNulls": false
             },
             "mappings": [],
             "thresholds": {
@@ -71,26 +56,27 @@
                   "value": 80
                 }
               ]
-            },
-            "unit": "requests"
+            }
           },
           "overrides": []
         },
         "gridPos": {
-          "h": 8,
-          "w": 12,
+          "h": 6,
+          "w": 24,
           "x": 0,
-          "y": 1
+          "y": 0
         },
-        "id": 1,
+        "id": 5,
         "options": {
-          "combine": false,
+          "alignValue": "left",
           "legend": {
-            "calcs": [],
             "displayMode": "list",
             "placement": "bottom",
             "showLegend": false
           },
+          "mergeValues": true,
+          "rowHeight": 0.9,
+          "showValue": "never",
           "tooltip": {
             "mode": "single",
             "sort": "none"
@@ -99,14 +85,84 @@
         "pluginVersion": "11.4.0",
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "orchestrator-mimir"
-            },
             "disableTextWrap": false,
             "editorMode": "builder",
-            "exemplar": false,
-            "expr": "cluster_manager_http_response_time_seconds_histogram_bucket",
+            "expr": "sum by(instance) (cluster_manager_http_response_codes_counter)",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Cluster Manager instance timeline",
+        "type": "state-timeline"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "orchestrator-mimir"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 6
+        },
+        "id": 2,
+        "options": {
+          "displayMode": "gradient",
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "maxVizHeight": 300,
+          "minVizHeight": 16,
+          "minVizWidth": 8,
+          "namePlacement": "auto",
+          "orientation": "auto",
+          "reduceOptions": {
+            "calcs": [
+              "diff"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "valueMode": "color"
+        },
+        "pluginVersion": "11.4.0",
+        "targets": [
+          {
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "cluster_manager_http_response_time_seconds_histogram_bucket{instance=\"$instance\"}",
             "format": "heatmap",
             "fullMetaSearch": false,
             "includeNullMetadata": true,
@@ -116,8 +172,8 @@
             "useBackend": false
           }
         ],
-        "title": "Histogram of HTTP response time (seconds)",
-        "type": "histogram"
+        "title": "HTTP response time for instance ${instance}",
+        "type": "bargauge"
       },
       {
         "datasource": {
@@ -150,9 +206,9 @@
           "h": 8,
           "w": 12,
           "x": 12,
-          "y": 1
+          "y": 6
         },
-        "id": 3,
+        "id": 1,
         "options": {
           "colorMode": "value",
           "graphMode": "area",
@@ -161,7 +217,7 @@
           "percentChangeColorMode": "standard",
           "reduceOptions": {
             "calcs": [
-              "lastNotNull"
+              "diff"
             ],
             "fields": "",
             "values": false
@@ -173,38 +229,244 @@
         "pluginVersion": "11.4.0",
         "targets": [
           {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "orchestrator-mimir"
+            },
             "disableTextWrap": false,
             "editorMode": "builder",
             "exemplar": false,
-            "expr": "sum by(code) (cluster_manager_http_response_codes_counter)",
-            "format": "time_series",
+            "expr": "cluster_manager_http_response_codes_counter{instance=\"$instance\"}",
             "fullMetaSearch": false,
             "includeNullMetadata": true,
-            "interval": "",
+            "instant": false,
             "legendFormat": "{{code}}",
             "range": true,
             "refId": "A",
             "useBackend": false
           }
         ],
-        "title": "Response Codes counter",
+        "title": "Response codes counter for instance $instance",
         "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "orchestrator-mimir"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "custom": {
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "scaleDistribution": {
+                "type": "linear"
+              }
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 14
+        },
+        "id": 6,
+        "maxDataPoints": 25,
+        "options": {
+          "calculate": false,
+          "cellGap": 1,
+          "color": {
+            "exponent": 0.5,
+            "fill": "dark-orange",
+            "mode": "scheme",
+            "reverse": false,
+            "scale": "exponential",
+            "scheme": "Oranges",
+            "steps": 64
+          },
+          "exemplars": {
+            "color": "rgba(255,0,255,0.7)"
+          },
+          "filterValues": {
+            "le": 1e-9
+          },
+          "legend": {
+            "show": true
+          },
+          "rowsFrame": {
+            "layout": "auto"
+          },
+          "tooltip": {
+            "mode": "single",
+            "showColorScale": false,
+            "yHistogram": false
+          },
+          "yAxis": {
+            "axisPlacement": "left",
+            "reverse": false
+          }
+        },
+        "pluginVersion": "11.4.0",
+        "targets": [
+          {
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "cluster_manager_http_response_time_seconds_histogram_bucket{instance=\"$instance\"}",
+            "format": "heatmap",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "{{le}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "HTTP response time for instance ${instance}",
+        "type": "heatmap"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "orchestrator-mimir"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 14
+        },
+        "id": 7,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.4.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "orchestrator-mimir"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "exemplar": false,
+            "expr": "cluster_manager_http_response_codes_counter{instance=\"$instance\"}",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{code}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Response codes counter for instance $instance",
+        "type": "timeseries"
       }
     ],
     "preload": false,
+    "refresh": "30s",
     "schemaVersion": 40,
     "tags": [],
     "templating": {
-      "list": []
+      "list": [
+        {
+          "current": {
+            "text": "10.244.0.7:8080",
+            "value": "10.244.0.7:8080"
+          },
+          "definition": "label_values(cluster_manager_http_response_codes_counter,instance)",
+          "label": "instance",
+          "name": "instance",
+          "options": [],
+          "query": {
+            "qryType": 1,
+            "query": "label_values(cluster_manager_http_response_codes_counter,instance)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "type": "query"
+        }
+      ]
     },
     "time": {
-      "from": "now-5m",
+      "from": "now-1h",
       "to": "now"
     },
     "timepicker": {},
     "timezone": "browser",
     "title": "Cluster Orch - Cluster Manager",
-    "uid": "belcotnnxolj4d",
-    "version": 2,
+    "uid": "delnr7r1642kgf",
+    "version": 1,
     "weekStart": ""
 }

--- a/deployment/charts/cluster-manager/files/dashboards/dashboard.json
+++ b/deployment/charts/cluster-manager/files/dashboards/dashboard.json
@@ -1,0 +1,207 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 24,
+    "links": [],
+    "panels": [
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "panels": [],
+        "title": "Cluster Manager",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "orchestrator-mimir"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "lineWidth": 1,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 1
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.4.0",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "orchestrator-mimir"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "cluster_manager_http_response_time_seconds_histogram_bucket",
+            "format": "heatmap",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "{{le}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Histogram of HTTP response time (seconds)",
+        "type": "histogram"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "orchestrator-mimir"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 1
+        },
+        "id": 3,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "11.4.0",
+        "targets": [
+          {
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "exemplar": false,
+            "expr": "sum by(code) (cluster_manager_http_response_codes_counter)",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "interval": "",
+            "legendFormat": "{{code}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Response Codes counter",
+        "type": "stat"
+      }
+    ],
+    "preload": false,
+    "schemaVersion": 40,
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-5m",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "Cluster Orch - Cluster Manager",
+    "uid": "belcotnnxolj4d",
+    "version": 3,
+    "weekStart": ""
+}

--- a/deployment/charts/cluster-manager/files/dashboards/dashboard.json
+++ b/deployment/charts/cluster-manager/files/dashboards/dashboard.json
@@ -1,4 +1,4 @@
-  {
+{
     "annotations": {
       "list": [
         {
@@ -18,7 +18,7 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 1,
-    "id": 24,
+    "id": 7,
     "links": [],
     "panels": [
       {
@@ -116,10 +116,6 @@
                 {
                   "color": "green",
                   "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
                 }
               ]
             }

--- a/deployment/charts/cluster-manager/files/dashboards/dashboard.json
+++ b/deployment/charts/cluster-manager/files/dashboards/dashboard.json
@@ -18,7 +18,7 @@
     "editable": true,
     "fiscalYearStartMonth": 0,
     "graphTooltip": 0,
-    "id": 24,
+    "id": 17,
     "links": [],
     "panels": [
       {
@@ -84,6 +84,7 @@
         },
         "id": 1,
         "options": {
+          "combine": false,
           "legend": {
             "calcs": [],
             "displayMode": "list",
@@ -104,6 +105,7 @@
             },
             "disableTextWrap": false,
             "editorMode": "builder",
+            "exemplar": false,
             "expr": "cluster_manager_http_response_time_seconds_histogram_bucket",
             "format": "heatmap",
             "fullMetaSearch": false,
@@ -165,7 +167,7 @@
             "values": false
           },
           "showPercentChange": false,
-          "textMode": "auto",
+          "textMode": "value_and_name",
           "wideLayout": true
         },
         "pluginVersion": "11.4.0",
@@ -203,6 +205,6 @@
     "timezone": "browser",
     "title": "Cluster Orch - Cluster Manager",
     "uid": "belcotnnxolj4d",
-    "version": 4,
+    "version": 2,
     "weekStart": ""
 }

--- a/deployment/charts/cluster-manager/files/dashboards/dashboard.json.license
+++ b/deployment/charts/cluster-manager/files/dashboards/dashboard.json.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0

--- a/deployment/charts/cluster-manager/templates/configmap.yaml
+++ b/deployment/charts/cluster-manager/templates/configmap.yaml
@@ -30,3 +30,17 @@ metadata:
 data:
 {{ (.Files.Glob "files/openpolicyagent/v1/*.rego").AsConfig | indent 2 }}
 {{- end}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "cluster-manager.fullname" . }}-dashboards-orchestrator
+  labels:
+    grafana_dashboard: "orchestrator"
+    {{- include "cluster-manager.labels" . | nindent 4 }}
+  {{- with .Values.metrics.dashboardAdminFolder }}
+  annotations:
+    grafana_folder: {{ . }}
+  {{- end }}
+data:
+{{ (.Files.Glob "files/dashboards/*.json").AsConfig | indent 2 }}

--- a/deployment/charts/cluster-manager/values.yaml
+++ b/deployment/charts/cluster-manager/values.yaml
@@ -150,6 +150,7 @@ metrics:
         app: "template-controller-metrics-svc"
   serviceMonitor:
     labels: {}
+  dashboardAdminFolder: orchestrator
 
 webhookService:
   enabled: true


### PR DESCRIPTION
### Description

Based on this tutorial https://grafana.com/blog/2020/06/23/how-to-visualize-prometheus-histograms-in-grafana/
Created "histogram" and heatmap for cluster manager response times

It resolves comments from previous PR https://github.com/open-edge-platform/cluster-manager/pull/54

All charts are dependent on instance.
If cluster-manager was restarted (due to its update or overload) different instance should be selected.

Histogram, Heatmap and Stats shows difference in given time frame.
![image](https://github.com/user-attachments/assets/3f2539c4-e7b4-46de-8c1a-6e54321fdabc)

Bigger time frame to see when which instance was on 
![image](https://github.com/user-attachments/assets/b692fe30-0fad-4091-88cc-c0e4637332e8)

### Any Newly Introduced Dependencies
None.

### How Has This Been Tested?

UI in Grafana + `mage deploy:EdgeCluster` to do 200/201 traffic + web-ui opened with unathorized user to do 4XX noise

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code