### PR TITLE
chore: remove RS mirrors from CT

### DIFF
--- a/default-cluster-templates/baseline.json
+++ b/default-cluster-templates/baseline.json
@@ -37,15 +37,7 @@
             "mkdir -p /etc/systemd/system/rke2-server.service.d",
             "echo '[Service]\nEnvironmentFile=/etc/environment' > /etc/systemd/system/rke2-server.service.d/override.conf"
           ],
-          "privateRegistriesConfig": {
-            "mirrors": {
-              "edge-node-release-proxy.local": {
-                "endpoint": [
-                  "https://localhost.internal:9443"
-                ]
-              }
-            }
-          },
+          "privateRegistriesConfig": {},
           "serverConfig": {
             "cni": "calico",
             "cniMultusEnable": true,

--- a/default-cluster-templates/privileged.json
+++ b/default-cluster-templates/privileged.json
@@ -37,15 +37,7 @@
             "mkdir -p /etc/systemd/system/rke2-server.service.d",
             "echo '[Service]\nEnvironmentFile=/etc/environment' > /etc/systemd/system/rke2-server.service.d/override.conf"
           ],
-          "privateRegistriesConfig": {
-            "mirrors": {
-              "edge-node-release-proxy.local": {
-                "endpoint": [
-                  "https://localhost.internal:9443"
-                ]
-              }
-            }
-          },
+          "privateRegistriesConfig": {},
           "serverConfig": {
             "cni": "calico",
             "cniMultusEnable": true,

--- a/default-cluster-templates/restricted.json
+++ b/default-cluster-templates/restricted.json
@@ -37,15 +37,7 @@
             "mkdir -p /etc/systemd/system/rke2-server.service.d",
             "echo '[Service]\nEnvironmentFile=/etc/environment' > /etc/systemd/system/rke2-server.service.d/override.conf"
           ],
-          "privateRegistriesConfig": {
-            "mirrors": {
-              "edge-node-release-proxy.local": {
-                "endpoint": [
-                  "https://localhost.internal:9443"
-                ]
-              }
-            }
-          },
+          "privateRegistriesConfig": {},
           "serverConfig": {
             "cni": "calico",
             "cniMultusEnable": true,


### PR DESCRIPTION
### Description

Removed Release Service registry mirror (Caddy proxy) as it is no longer used.

In previous releases we had to use RS proxy on the Edge Node (Caddy) as Release Service required authentication (which was handled by the proxy transparently). Nowadays RS is open, hence we don't need to use proxy anymore to download container images.

### Any Newly Introduced Dependencies

No.

### How Has This Been Tested?

Via CI pipeline.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code