### PR TITLE
fix: make license target by bumping reuse package version to 5.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 # license checking
 python-debian==0.1.44
-reuse~=1.0.0
+reuse~=5.0.0
 
 # lint yaml
 yamllint~=1.27.1


### PR DESCRIPTION
### Description

before bump, we used reuse version 1.0.0 which wasn't able to understand REUSE.toml file.
In CI we use version 5.0.0
https://github.com/open-edge-platform/orch-ci/blob/main/.github/workflows/pre-merge.yml#L229

### Any Newly Introduced Dependencies
No.

### How Has This Been Tested?

`make license`

before
![image](https://github.com/user-attachments/assets/8f95a238-3d07-4fd4-a883-ecd228404452)
![image](https://github.com/user-attachments/assets/25e91e41-803a-4986-af39-8638bb57c2b3)

after
![image](https://github.com/user-attachments/assets/3ee0ce18-5307-46fc-807f-4576de550fad)
![image](https://github.com/user-attachments/assets/9037dc60-ea7e-4015-bc26-0fe35b748295)


### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code