### PR TITLE
fix to keep baseline as default template

### DIFF
--- a/internal/multitenancy/multitenancy.go
+++ b/internal/multitenancy/multitenancy.go
@@ -24,8 +24,8 @@ import (
 const appName = "cluster-manager"
 
 var (
-	nexusContextTimeout = time.Second * 5
-
+	baselineRegex         = regexp.MustCompile(`^baseline-v\d+\.\d+\.\d+`)	
+	nexusContextTimeout   = time.Second * 5
 	GetClusterConfigFunc  = rest.InClusterConfig
 	GetNexusClientSetFunc = nexus.NewForConfig
 	GetK8sClientFunc      = k8s.NewClient
@@ -157,7 +157,6 @@ func (tdm *TenancyDatamodel) setupProject(ctx context.Context, project *nexus.Ru
 
 	// Label default template
 	var defaultTemplateName string
-	baselineRegex := regexp.MustCompile(`^baseline-v\d+\.\d+\.\d+`)
 	for _, t := range tdm.templates {
 		if baselineRegex.MatchString(t.GetName()) {
 			defaultTemplateName = t.GetName()

--- a/internal/multitenancy/multitenancy.go
+++ b/internal/multitenancy/multitenancy.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -156,8 +157,9 @@ func (tdm *TenancyDatamodel) setupProject(ctx context.Context, project *nexus.Ru
 
 	// Label default template
 	var defaultTemplateName string
+	baselineRegex := regexp.MustCompile(`^baseline-v\d+\.\d+\.\d+`)
 	for _, t := range tdm.templates {
-		if t.GetName() == template.DefaultTemplateName {
+		if baselineRegex.MatchString(t.GetName()) {
 			defaultTemplateName = t.GetName()
 			break
 		}

--- a/internal/multitenancy/multitenancy.go
+++ b/internal/multitenancy/multitenancy.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -158,7 +157,7 @@ func (tdm *TenancyDatamodel) setupProject(ctx context.Context, project *nexus.Ru
 	// Label default template
 	var defaultTemplateName string
 	for _, t := range tdm.templates {
-		if strings.Contains(t.GetName(), template.DefaultTemplateName) {
+		if t.GetName() == template.DefaultTemplateName {
 			defaultTemplateName = t.GetName()
 			break
 		}

--- a/internal/template/templates.go
+++ b/internal/template/templates.go
@@ -17,8 +17,6 @@ import (
 	"github.com/open-edge-platform/cluster-manager/v2/pkg/api"
 )
 
-const DefaultTemplateName = "baseline"
-
 var namesemverRegex = regexp.MustCompile(`^(?P<name>.*)-v(?P<semver>\d+\.\d+\.\d+.*)$`)
 
 // fromTemplateInfoToClusterTemplate translates a TemplateInfo object to a ClusterTemplate object


### PR DESCRIPTION
### Description

We are working on fixing the behavior change caused by new templates added to the default templates folder. Right now, we want to keep the 'baseline' template as the default. The new template with 'baseline' in its name accidentally became the default. This PR sorts that out for now. We'll soon add a way to choose which template should be the default.

Fixes # (issue)

### Any Newly Introduced Dependencies
no

### How Has This Been Tested?
make test
make test-service

```
Ran 14 of 14 Specs in 19.736 seconds
SUCCESS! -- 14 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestService (19.74s)
PASS
ok      github.com/open-edge-platform/cluster-manager/v2/test/service   19.750s

```
also checked in the UI
<img width="611" alt="image" src="https://github.com/user-attachments/assets/8b1d51a7-fdaf-4385-ae75-f2ab5c71a265" />


### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code