### PR TITLE
fix /v2/clusters response status in Grafana Dashboard

### DIFF
--- a/deployment/charts/cluster-manager/files/dashboards/cluster-manager-dashboard.json
+++ b/deployment/charts/cluster-manager/files/dashboards/cluster-manager-dashboard.json
@@ -179,7 +179,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "palette-classic"
           },
           "mappings": [],
           "thresholds": {
@@ -188,10 +188,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }


### PR DESCRIPTION
### Description

Fix /v2/clusters response status in Grafana Dashboard.

### How Has This Been Tested?

By manually applying changes to the dashboard. 

Before:
![image](https://github.com/user-attachments/assets/a7590efc-8adc-439c-9c41-057a81a33e9f)

After:
![image](https://github.com/user-attachments/assets/a55565cc-6b30-4f75-9149-f7486245904b)


### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code