### PR TITLE
fix: CT creation, host cleanup finalizer

### DIFF
--- a/internal/multitenancy/multitenancy.go
+++ b/internal/multitenancy/multitenancy.go
@@ -157,7 +157,7 @@ func (tdm *TenancyDatamodel) setupProject(ctx context.Context, project *nexus.Ru
 	// Create namespace
 	err := tdm.k8s.CreateNamespace(ctx, projectId)
 	if err != nil {
-		slog.Warn("failed to create namespace for project: %v", err)
+		slog.Warn(fmt.Sprintf("failed to create namespace for project: %v", err))
 	} else {
 		slog.Debug("created namespace for project", "namespace", projectId, "project", project.DisplayName())
 	}
@@ -166,7 +166,7 @@ func (tdm *TenancyDatamodel) setupProject(ctx context.Context, project *nexus.Ru
 	for _, template := range tdm.templates {
 		err = tdm.k8s.CreateTemplate(ctx, projectId, template)
 		if err != nil {
-			slog.Warn("failed to create '%s' default template: %w", template.GetName(), err)
+			slog.Warn(fmt.Sprintf("failed to create '%s' default template: %v", template.GetName(), err))
 		} else {
 			slog.Debug("created template", "namespace", projectId, "template", template.GetName(), "project", project.DisplayName())
 		}

--- a/internal/multitenancy/multitenancy.go
+++ b/internal/multitenancy/multitenancy.go
@@ -157,18 +157,20 @@ func (tdm *TenancyDatamodel) setupProject(ctx context.Context, project *nexus.Ru
 	// Create namespace
 	err := tdm.k8s.CreateNamespace(ctx, projectId)
 	if err != nil {
-		return fmt.Errorf("failed to create namespace for project: %w", err)
+		slog.Warn("failed to create namespace for project: %v", err)
+	} else {
+		slog.Debug("created namespace for project", "namespace", projectId, "project", project.DisplayName())
 	}
-	slog.Debug("created namespace for project", "namespace", projectId, "project", project.DisplayName())
 
 	// Apply templates
 	for _, template := range tdm.templates {
 		err = tdm.k8s.CreateTemplate(ctx, projectId, template)
 		if err != nil {
-			return fmt.Errorf("failed to apply '%s' default template: %w", template.GetName(), err)
+			slog.Warn("failed to create '%s' default template: %w", template.GetName(), err)
+		} else {
+			slog.Debug("created template", "namespace", projectId, "template", template.GetName(), "project", project.DisplayName())
 		}
 	}
-	slog.Debug("added default cluster templates to project", "namespace", projectId, "project", project.DisplayName())
 
 	defaultTemplateName := selectDefaultTemplateName(tdm.templates, disableK3sTemplates)
 

--- a/internal/rest/deletev2clustersnameNodeId.go
+++ b/internal/rest/deletev2clustersnameNodeId.go
@@ -4,22 +4,16 @@ package rest
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 
-	jsonpatch "github.com/evanphx/json-patch"
-	intelProvider "github.com/open-edge-platform/cluster-api-provider-intel/api/v1alpha1"
 	"github.com/open-edge-platform/cluster-manager/v2/internal/core"
-	"github.com/open-edge-platform/cluster-manager/v2/internal/k8s"
 	"github.com/open-edge-platform/cluster-manager/v2/pkg/api"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
-	cutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // (DELETE /v2/clusters/{name}/nodes/{nodeId})
@@ -27,10 +21,8 @@ func (s *Server) DeleteV2ClustersNameNodesNodeId(ctx context.Context, request ap
 	activeProjectID := request.Params.Activeprojectid.String()
 	// first check if we're dealing with a single node cluster
 	clusterName := request.Name
-	var force bool
 	deleteOptions := v1.DeleteOptions{}
 	if request.Params.Force != nil && *request.Params.Force {
-		force = true
 		// set grace period to 0 for force delete
 		deleteOptions = v1.DeleteOptions{GracePeriodSeconds: new(int64)}
 		*deleteOptions.GracePeriodSeconds = 0
@@ -46,45 +38,7 @@ func (s *Server) DeleteV2ClustersNameNodesNodeId(ctx context.Context, request ap
 		slog.Error(errMsg)
 		return api.DeleteV2ClustersNameNodesNodeId400JSONResponse{N400BadRequestJSONResponse: api.N400BadRequestJSONResponse{Message: &errMsg}}, nil
 	}
-	if force {
-		// track down the machine binding and remove the finalizer
-		// a cluster object may not exist for it anymore so we want to do this first before erroring out
-		cli, err := k8s.New(k8s.WithDynamicClient(s.k8sclient))
-		if err != nil {
-			errMsg := fmt.Sprintf("failed to create k8s client: %v", err)
-			slog.Error(errMsg)
-			return api.DeleteV2ClustersNameNodesNodeId500JSONResponse{N500InternalServerErrorJSONResponse: api.N500InternalServerErrorJSONResponse{Message: &errMsg}}, nil
-		}
-		intelMachines, err := cli.IntelMachines(ctx, activeProjectID, clusterName)
-		if err != nil {
-			errMsg := "failed to retrieve intel machines"
-			slog.Error(errMsg, "error", err)
-			return api.DeleteV2ClustersNameNodesNodeId500JSONResponse{N500InternalServerErrorJSONResponse: api.N500InternalServerErrorJSONResponse{Message: &errMsg}}, nil
-		}
-		// once host-id is used instead of uuid we should check the machine's host-id and only remove the finalizer if it matches
-		// for now this works fine for single node clusters
-		for _, intelMachine := range intelMachines {
-			origIntelMachine := intelMachine.DeepCopy()
-			if !cutil.RemoveFinalizer(&intelMachine, intelProvider.HostCleanupFinalizer) {
-				// we don't error out just in case the finalizer was already removed but deletion still needs to be triggered
-				errMsg := "failed to remove finalizers"
-				slog.Error(errMsg)
-				continue
-			}
-			intelMachineBytes, err := getPatchData(origIntelMachine, intelMachine)
-			if err != nil {
-				errMsg := "failed to get patch data"
-				slog.Error(errMsg, "error", err)
-				continue
-			}
-			_, err = s.k8sclient.Resource(core.IntelMachineResourceSchema).Namespace(activeProjectID).Patch(ctx, intelMachine.Name, types.MergePatchType, intelMachineBytes, v1.PatchOptions{})
-			if err != nil {
-				errMsg := "failed to remove finalizers"
-				slog.Error(errMsg, "error", err)
-				continue
-			}
-		}
-	}
+
 	// retrieve the cluster
 	cluster, err := s.getCluster(ctx, activeProjectID, clusterName)
 	if err != nil {
@@ -149,22 +103,4 @@ func scaleDownCluster(ctx context.Context, s *Server, capiCluster *capi.Cluster,
 	unstructuredCluster := &unstructured.Unstructured{Object: unstructuredClusterInfo}
 	_, err = s.k8sclient.Resource(core.ClusterResourceSchema).Namespace(capiCluster.Namespace).Update(ctx, unstructuredCluster, v1.UpdateOptions{})
 	return err
-}
-
-// getPatchData will return difference between original and modified document
-func getPatchData(originalObj, modifiedObj interface{}) ([]byte, error) {
-	originalData, err := json.Marshal(originalObj)
-	if err != nil {
-		return nil, err
-	}
-	modifiedData, err := json.Marshal(modifiedObj)
-	if err != nil {
-		return nil, err
-	}
-
-	patchBytes, err := jsonpatch.CreateMergePatch(originalData, modifiedData)
-	if err != nil {
-		return nil, err
-	}
-	return patchBytes, nil
 }

--- a/internal/rest/deletev2clustersnameNodeId_test.go
+++ b/internal/rest/deletev2clustersnameNodeId_test.go
@@ -128,50 +128,6 @@ func TestDeleteClustersNameNodeId(t *testing.T) {
 		machineResource := k8s.NewMockResourceInterface(t)
 		intelMachineResource := k8s.NewMockResourceInterface(t)
 		intelMachineResource.EXPECT().Get(mock.Anything, mock.Anything, metav1.GetOptions{}).Return(&unstructured.Unstructured{Object: map[string]interface{}{}}, nil)
-		intelMachineResource.EXPECT().List(mock.Anything, metav1.ListOptions{LabelSelector: "cluster.x-k8s.io/cluster-name=" + name}).Return(&unstructured.UnstructuredList{
-			Items: []unstructured.Unstructured{
-				{
-					Object: map[string]interface{}{
-						"apiVersion": "cluster.k8s.io/v1alpha1",
-						"kind":       "IntelMachine",
-						"metadata": map[string]interface{}{
-							"name":      "machine1",
-							"namespace": activeProjectID,
-							"annotations": map[string]interface{}{
-								"intelmachine.infrastructure.cluster.x-k8s.io/host-id": nodeID,
-							},
-							"finalizers": []string{"intelmachine.infrastructure.cluster.x-k8s.io/host-cleanup"},
-						},
-						"status": map[string]interface{}{
-							"nodeRef": map[string]interface{}{
-								"uid": nodeID,
-							},
-						},
-						"spec": map[string]interface{}{},
-					},
-				},
-				{
-					Object: map[string]interface{}{
-						"apiVersion": "cluster.k8s.io/v1alpha1",
-						"kind":       "IntelMachine",
-						"metadata": map[string]interface{}{
-							"name":      "machine2",
-							"namespace": activeProjectID,
-							"annotations": map[string]interface{}{
-								"intelmachine.infrastructure.cluster.x-k8s.io/host-id": "different-id",
-							},
-						},
-						"status": map[string]interface{}{
-							"nodeRef": map[string]interface{}{
-								"uid": "different-node-id",
-							},
-						},
-						"spec": map[string]interface{}{},
-					},
-				},
-			},
-		}, nil)
-		intelMachineResource.EXPECT().Patch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&unstructured.Unstructured{}, nil)
 		clusterResource.EXPECT().Get(mock.Anything, name, metav1.GetOptions{}).Return(&unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"apiVersion": "v1",


### PR DESCRIPTION
### Description

Minor fixes:
- continue creating Cluster Templates on error; it handles the upgrade case where some CT may be already present (e.g. rke2) and some not (e.g. k3s)
- remove host cleanup finalizer removal - the finalizer is no longer used

### How Has This Been Tested?

Manualy on local Orchestrator instance.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code