### PR TITLE
chore: romve Józef & Julia from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-*  @eoghanlawless @jokuniew @hyunsun @gcgirish @jdanieck
+*  @eoghanlawless @hyunsun @gcgirish


### PR DESCRIPTION
### Description

Removed Józef & Julia from codeowners as w no longer work on EMF.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code