### PR TITLE
Add scott to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-*  @eoghanlawless @hyunsun @gcgirish
+*  @eoghanlawless @hyunsun @gcgirish @scottmbaker


### PR DESCRIPTION
### Description

Add scott to codeowners for US daytime code reviews.

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code