### PR TITLE
feat: implement m2m authentication for kubeconfig with configurable jwt TTL

### DIFF
--- a/cmd/cluster-manager/main.go
+++ b/cmd/cluster-manager/main.go
@@ -4,10 +4,12 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
 
+	"github.com/open-edge-platform/cluster-manager/v2/internal/auth"
 	"github.com/open-edge-platform/cluster-manager/v2/internal/config"
 	"github.com/open-edge-platform/cluster-manager/v2/internal/k8s"
 	"github.com/open-edge-platform/cluster-manager/v2/internal/labels"
@@ -56,6 +58,22 @@ func main() {
 		slog.Error("failed to initialize k8s clientset")
 		os.Exit(3)
 	}
+
+	// Initialize VaultAuth and fetch client credentials
+	vaultAuth, err := auth.NewVaultAuth(auth.VaultServer, auth.ServiceAccount)
+	if err != nil {
+		slog.Error("failed to initialize VaultAuth", "error", err)
+		os.Exit(4)
+	}
+
+	clientID, clientSecret, err := vaultAuth.GetClientCredentials(context.Background())
+	if err != nil {
+		slog.Error("failed to fetch client credentials from Vault", "error", err)
+		os.Exit(4)
+	}
+	// testing the client credentials
+	slog.Info("Successfully retrieved client credentials from Vault", "client_id", clientID)
+	slog.Info("Successfully retrieved client credentials from Vault", "client_secret", clientSecret)
 
 	auth, err := rest.GetAuthenticator(config)
 	if err != nil {

--- a/cmd/cluster-manager/main.go
+++ b/cmd/cluster-manager/main.go
@@ -104,9 +104,5 @@ func initializeAuth(config *config.Config) {
 			slog.Error("failed to fetch client credentials from Vault", "error", err)
 			os.Exit(4)
 		}
-		// Credentials retrieved successfully - do not log sensitive values
-		slog.Info("Successfully retrieved client credentials from Vault")
-	} else {
-		slog.Info("Authentication disabled, skipping Vault initialization")
 	}
 }

--- a/internal/auth/clusterapitoken.go
+++ b/internal/auth/clusterapitoken.go
@@ -78,7 +78,7 @@ func JwtTokenWithM2M(ctx context.Context, ttl *time.Duration) (string, error) {
 	data.Set("grant_type", "client_credentials")
 	data.Set("client_id", clientID)
 	data.Set("client_secret", clientSecret)
-	
+
 	// Add custom TTL if supported by Keycloak configuration
 	// Note: This may require custom Keycloak configuration to respect the TTL parameter
 	if ttl != nil {

--- a/internal/auth/clusterapitoken.go
+++ b/internal/auth/clusterapitoken.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+// JwtToken retrieves a new token from Keycloak
+func JwtToken(keycloakURL, accessToken string) (*TokenResponse, error) {
+	clientId, username, _, _ := ExtractClaims(accessToken)
+	password := os.Getenv("PASSWORD")
+
+	data := url.Values{}
+	data.Set("grant_type", "password")
+	data.Set("client_id", clientId)
+	data.Set("username", username)
+	data.Set("password", password)
+
+	tokenURL := fmt.Sprintf("%s/protocol/openid-connect/token", keycloakURL)
+	req, err := http.NewRequest("POST", tokenURL, bytes.NewBufferString(data.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to refresh token, status code: %d", resp.StatusCode)
+	}
+	var tokenResponse TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResponse); err != nil {
+		return nil, err
+	}
+
+	return &tokenResponse, nil
+}
+
+// ExtractClaims extracts claims from a JWT token
+func ExtractClaims(tokenString string) (string, string, time.Time, error) {
+	// Parse the token without verifying the signature to extract the claims
+	// but since the token has passed the auth check, we can trust the claims - Confirm
+	token, _, err := new(jwt.Parser).ParseUnverified(tokenString, jwt.MapClaims{})
+	if err != nil {
+		return "", "", time.Time{}, fmt.Errorf("failed to parse token: %w", err)
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return "", "", time.Time{}, fmt.Errorf("failed to extract claims")
+	}
+
+	azp, _ := claims["azp"].(string) // authorized party
+	preferredUsername, _ := claims["preferred_username"].(string)
+
+	exp, ok := claims["exp"].(float64) // expire time
+	if !ok {
+		return azp, preferredUsername, time.Time{}, fmt.Errorf("invalid or missing exp claim")
+	}
+
+	expirationTime := time.Unix(int64(exp), 0) // convert to time.Time
+
+	return azp, preferredUsername, expirationTime, nil
+}

--- a/internal/auth/clusterapitoken_test.go
+++ b/internal/auth/clusterapitoken_test.go
@@ -3,9 +3,9 @@
 package auth
 
 import (
+	"os"
 	"testing"
 	"time"
-	"os"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
@@ -159,25 +159,25 @@ func TestJwtTokenWithM2M(t *testing.T) {
 			name:        "successful M2M token with 1 hour TTL",
 			ttl:         func() *time.Duration { d := 1 * time.Hour; return &d }(),
 			expectedTTL: 1 * time.Hour,
-			skipReason:  "Function will be implemented in next PR",
+			skipReason:  "TODO: Integration test requires Vault and Keycloak setup",
 		},
 		{
-			name:        "successful M2M token with 24 hour TTL", 
+			name:        "successful M2M token with 24 hour TTL",
 			ttl:         func() *time.Duration { d := 24 * time.Hour; return &d }(),
 			expectedTTL: 24 * time.Hour,
-			skipReason:  "Function will be implemented in next PR",
+			skipReason:  "TODO: Integration test requires Vault and Keycloak setup",
 		},
 		{
 			name:        "successful M2M token without TTL (use default)",
 			ttl:         nil,
 			expectedTTL: 1 * time.Hour, // Default TTL
-			skipReason:  "Function will be implemented in next PR",
+			skipReason:  "TODO: Integration test requires Vault and Keycloak setup",
 		},
 		{
 			name:        "M2M token with empty roles",
 			ttl:         func() *time.Duration { d := 2 * time.Hour; return &d }(),
 			expectedTTL: 2 * time.Hour,
-			skipReason:  "Function will be implemented in next PR",
+			skipReason:  "TODO: Integration test requires Vault and Keycloak setup",
 		},
 	}
 
@@ -187,31 +187,31 @@ func TestJwtTokenWithM2M(t *testing.T) {
 			if testing.Short() {
 				t.Skip("Skipping integration test in short mode")
 			}
-			
+
 			// Check if required environment variables are set
 			keycloakURL := os.Getenv("KEYCLOAK_URL")
 			if keycloakURL == "" {
 				t.Skip("KEYCLOAK_URL not set, skipping integration test")
 			}
-			
+
 			// TODO: Implement when external services are properly mocked or available
 			// For now, skip these tests since they require Vault and Keycloak
-			t.Skip("Integration test requires Vault and Keycloak setup")
-			
+			t.Skip("TODO: Integration test requires Vault and Keycloak setup")
+
 			// token, err := JwtTokenWithM2M(context.Background(), tt.ttl)
 			// require.NoError(t, err)
 			// assert.NotEmpty(t, token)
-			
+
 			// // Validate TTL
-			// ttl, err := helpers.ExtractTokenTTL(token)  
+			// ttl, err := helpers.ExtractTokenTTL(token)
 			// require.NoError(t, err)
 			// tolerance := 1 * time.Minute
 			// diff := ttl - tt.expectedTTL
 			// if diff < 0 {
 			//     diff = -diff
 			// }
-			// assert.True(t, diff <= tolerance, 
-			//     "Token TTL %v should be within %v of expected %v", 
+			// assert.True(t, diff <= tolerance,
+			//     "Token TTL %v should be within %v of expected %v",
 			//     ttl, tolerance, tt.expectedTTL)
 		})
 	}
@@ -224,7 +224,6 @@ func TestExtractUserRoles(t *testing.T) {
 		tokenClaims   jwt.MapClaims
 		expectedRoles []string
 		expectedError bool
-		skipReason    string
 	}{
 		{
 			name: "token with multiple roles",
@@ -235,7 +234,6 @@ func TestExtractUserRoles(t *testing.T) {
 			},
 			expectedRoles: []string{"admin", "user", "cluster-reader"},
 			expectedError: false,
-			skipReason:    "Function will be implemented in next PR",
 		},
 		{
 			name: "token with single role",
@@ -246,7 +244,6 @@ func TestExtractUserRoles(t *testing.T) {
 			},
 			expectedRoles: []string{"user"},
 			expectedError: false,
-			skipReason:    "Function will be implemented in next PR",
 		},
 		{
 			name: "token with no roles",
@@ -257,7 +254,6 @@ func TestExtractUserRoles(t *testing.T) {
 			},
 			expectedRoles: []string{},
 			expectedError: false,
-			skipReason:    "Function will be implemented in next PR",
 		},
 		{
 			name: "token without realm_access",
@@ -266,7 +262,6 @@ func TestExtractUserRoles(t *testing.T) {
 			},
 			expectedRoles: nil,
 			expectedError: true,
-			skipReason:    "Function will be implemented in next PR",
 		},
 		{
 			name: "token with invalid roles format",
@@ -277,7 +272,6 @@ func TestExtractUserRoles(t *testing.T) {
 			},
 			expectedRoles: nil,
 			expectedError: true,
-			skipReason:    "Function will be implemented in next PR",
 		},
 	}
 
@@ -285,7 +279,7 @@ func TestExtractUserRoles(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test the actual ExtractUserRoles function
 			roles, err := ExtractUserRoles(tt.tokenClaims)
-			
+
 			if tt.expectedError {
 				assert.Error(t, err)
 				assert.Nil(t, roles)
@@ -342,7 +336,7 @@ func TestTokenTTLValidation(t *testing.T) {
 			// Test TTL validation logic
 			minTTL := 10 * time.Minute
 			maxTTL := 14 * 24 * time.Hour // 14 days
-			
+
 			isValid := tt.ttl >= minTTL && tt.ttl <= maxTTL
 			assert.Equal(t, tt.expectValid, isValid, tt.description)
 		})

--- a/internal/auth/clusterapitoken_test.go
+++ b/internal/auth/clusterapitoken_test.go
@@ -5,6 +5,7 @@ package auth
 import (
 	"testing"
 	"time"
+	"os"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
@@ -182,14 +183,27 @@ func TestJwtTokenWithM2M(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Skip(tt.skipReason)
-			// TODO: Implement when JwtTokenWithM2M function is available
+			// Skip integration tests if external services are not available
+			if testing.Short() {
+				t.Skip("Skipping integration test in short mode")
+			}
+			
+			// Check if required environment variables are set
+			keycloakURL := os.Getenv("KEYCLOAK_URL")
+			if keycloakURL == "" {
+				t.Skip("KEYCLOAK_URL not set, skipping integration test")
+			}
+			
+			// TODO: Implement when external services are properly mocked or available
+			// For now, skip these tests since they require Vault and Keycloak
+			t.Skip("Integration test requires Vault and Keycloak setup")
+			
 			// token, err := JwtTokenWithM2M(context.Background(), tt.ttl)
 			// require.NoError(t, err)
 			// assert.NotEmpty(t, token)
 			
 			// // Validate TTL
-			// ttl, err := ExtractTokenTTL(token)  
+			// ttl, err := helpers.ExtractTokenTTL(token)  
 			// require.NoError(t, err)
 			// tolerance := 1 * time.Minute
 			// diff := ttl - tt.expectedTTL
@@ -269,16 +283,16 @@ func TestExtractUserRoles(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Skip(tt.skipReason)
-			// TODO: Implement when ExtractUserRoles function is available
-			// roles, err := ExtractUserRoles(tt.tokenClaims)
-			// 
-			// if tt.expectedError {
-			//     require.Error(t, err)
-			// } else {
-			//     require.NoError(t, err)
-			//     assert.Equal(t, tt.expectedRoles, roles)
-			// }
+			// Test the actual ExtractUserRoles function
+			roles, err := ExtractUserRoles(tt.tokenClaims)
+			
+			if tt.expectedError {
+				assert.Error(t, err)
+				assert.Nil(t, roles)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedRoles, roles)
+			}
 		})
 	}
 }

--- a/internal/auth/clusterapitoken_test.go
+++ b/internal/auth/clusterapitoken_test.go
@@ -145,3 +145,192 @@ func TestExtractClaims(t *testing.T) {
 		})
 	}
 }
+
+// TestJwtTokenWithM2M tests the M2M token generation function
+func TestJwtTokenWithM2M(t *testing.T) {
+	tests := []struct {
+		name        string
+		ttl         *time.Duration
+		expectedTTL time.Duration
+		skipReason  string
+	}{
+		{
+			name:        "successful M2M token with 1 hour TTL",
+			ttl:         func() *time.Duration { d := 1 * time.Hour; return &d }(),
+			expectedTTL: 1 * time.Hour,
+			skipReason:  "Function will be implemented in next PR",
+		},
+		{
+			name:        "successful M2M token with 24 hour TTL", 
+			ttl:         func() *time.Duration { d := 24 * time.Hour; return &d }(),
+			expectedTTL: 24 * time.Hour,
+			skipReason:  "Function will be implemented in next PR",
+		},
+		{
+			name:        "successful M2M token without TTL (use default)",
+			ttl:         nil,
+			expectedTTL: 1 * time.Hour, // Default TTL
+			skipReason:  "Function will be implemented in next PR",
+		},
+		{
+			name:        "M2M token with empty roles",
+			ttl:         func() *time.Duration { d := 2 * time.Hour; return &d }(),
+			expectedTTL: 2 * time.Hour,
+			skipReason:  "Function will be implemented in next PR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Skip(tt.skipReason)
+			// TODO: Implement when JwtTokenWithM2M function is available
+			// token, err := JwtTokenWithM2M(context.Background(), tt.ttl)
+			// require.NoError(t, err)
+			// assert.NotEmpty(t, token)
+			
+			// // Validate TTL
+			// ttl, err := ExtractTokenTTL(token)  
+			// require.NoError(t, err)
+			// tolerance := 1 * time.Minute
+			// diff := ttl - tt.expectedTTL
+			// if diff < 0 {
+			//     diff = -diff
+			// }
+			// assert.True(t, diff <= tolerance, 
+			//     "Token TTL %v should be within %v of expected %v", 
+			//     ttl, tolerance, tt.expectedTTL)
+		})
+	}
+}
+
+// TestExtractUserRoles tests user role extraction from JWT tokens
+func TestExtractUserRoles(t *testing.T) {
+	tests := []struct {
+		name          string
+		tokenClaims   jwt.MapClaims
+		expectedRoles []string
+		expectedError bool
+		skipReason    string
+	}{
+		{
+			name: "token with multiple roles",
+			tokenClaims: jwt.MapClaims{
+				"realm_access": map[string]interface{}{
+					"roles": []interface{}{"admin", "user", "cluster-reader"},
+				},
+			},
+			expectedRoles: []string{"admin", "user", "cluster-reader"},
+			expectedError: false,
+			skipReason:    "Function will be implemented in next PR",
+		},
+		{
+			name: "token with single role",
+			tokenClaims: jwt.MapClaims{
+				"realm_access": map[string]interface{}{
+					"roles": []interface{}{"user"},
+				},
+			},
+			expectedRoles: []string{"user"},
+			expectedError: false,
+			skipReason:    "Function will be implemented in next PR",
+		},
+		{
+			name: "token with no roles",
+			tokenClaims: jwt.MapClaims{
+				"realm_access": map[string]interface{}{
+					"roles": []interface{}{},
+				},
+			},
+			expectedRoles: []string{},
+			expectedError: false,
+			skipReason:    "Function will be implemented in next PR",
+		},
+		{
+			name: "token without realm_access",
+			tokenClaims: jwt.MapClaims{
+				"azp": "test-client",
+			},
+			expectedRoles: nil,
+			expectedError: true,
+			skipReason:    "Function will be implemented in next PR",
+		},
+		{
+			name: "token with invalid roles format",
+			tokenClaims: jwt.MapClaims{
+				"realm_access": map[string]interface{}{
+					"roles": "invalid-format",
+				},
+			},
+			expectedRoles: nil,
+			expectedError: true,
+			skipReason:    "Function will be implemented in next PR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Skip(tt.skipReason)
+			// TODO: Implement when ExtractUserRoles function is available
+			// roles, err := ExtractUserRoles(tt.tokenClaims)
+			// 
+			// if tt.expectedError {
+			//     require.Error(t, err)
+			// } else {
+			//     require.NoError(t, err)
+			//     assert.Equal(t, tt.expectedRoles, roles)
+			// }
+		})
+	}
+}
+
+// TestTokenTTLValidation tests TTL validation logic
+func TestTokenTTLValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		ttl         time.Duration
+		expectValid bool
+		description string
+	}{
+		{
+			name:        "valid 1 hour TTL",
+			ttl:         1 * time.Hour,
+			expectValid: true,
+			description: "1 hour is within valid range",
+		},
+		{
+			name:        "valid 24 hour TTL",
+			ttl:         24 * time.Hour,
+			expectValid: true,
+			description: "24 hours is within valid range",
+		},
+		{
+			name:        "valid 7 day TTL",
+			ttl:         7 * 24 * time.Hour,
+			expectValid: true,
+			description: "7 days is within valid range",
+		},
+		{
+			name:        "too short TTL (5 minutes)",
+			ttl:         5 * time.Minute,
+			expectValid: false,
+			description: "5 minutes is below minimum TTL",
+		},
+		{
+			name:        "too long TTL (30 days)",
+			ttl:         30 * 24 * time.Hour,
+			expectValid: false,
+			description: "30 days exceeds maximum TTL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test TTL validation logic
+			minTTL := 10 * time.Minute
+			maxTTL := 14 * 24 * time.Hour // 14 days
+			
+			isValid := tt.ttl >= minTTL && tt.ttl <= maxTTL
+			assert.Equal(t, tt.expectValid, isValid, tt.description)
+		})
+	}
+}

--- a/internal/auth/clusterapitoken_test.go
+++ b/internal/auth/clusterapitoken_test.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractClaims(t *testing.T) {
+	tests := []struct {
+		name          string
+		tokenClaims   jwt.MapClaims
+		expectedError bool
+		expectedAzp   string
+		expectedUser  string
+		expectedExp   time.Time
+	}{
+		{
+			name: "valid token",
+			tokenClaims: jwt.MapClaims{
+				"azp":                "test-client-id",
+				"preferred_username": "test-username",
+				"exp":                time.Now().Add(time.Hour).Unix(),
+			},
+			expectedError: false,
+			expectedAzp:   "test-client-id",
+			expectedUser:  "test-username",
+			expectedExp:   time.Now().Add(time.Hour),
+		},
+		{
+			name:          "invalid token",
+			tokenClaims:   nil,
+			expectedError: true,
+		},
+		{
+			name: "token without exp claim",
+			tokenClaims: jwt.MapClaims{
+				"azp":                "test-client-id",
+				"preferred_username": "test-username",
+			},
+			expectedError: true,
+			expectedAzp:   "test-client-id",
+			expectedUser:  "test-username",
+			expectedExp:   time.Time{},
+		},
+		{
+			name: "token with missing azp claim",
+			tokenClaims: jwt.MapClaims{
+				"preferred_username": "test-username",
+				"exp":                time.Now().Add(time.Hour).Unix(),
+			},
+			expectedError: false,
+			expectedAzp:   "",
+			expectedUser:  "test-username",
+			expectedExp:   time.Now().Add(time.Hour),
+		},
+		{
+			name: "token with missing preferred_username claim",
+			tokenClaims: jwt.MapClaims{
+				"azp": "test-client-id",
+				"exp": time.Now().Add(time.Hour).Unix(),
+			},
+			expectedError: false,
+			expectedAzp:   "test-client-id",
+			expectedUser:  "",
+			expectedExp:   time.Now().Add(time.Hour),
+		},
+		{
+			name: "token with invalid exp claim",
+			tokenClaims: jwt.MapClaims{
+				"azp":                "test-client-id",
+				"preferred_username": "test-username",
+				"exp":                "invalid-exp",
+			},
+			expectedError: true,
+		},
+		{
+			name: "expired token",
+			tokenClaims: jwt.MapClaims{
+				"azp":                "test-client-id",
+				"preferred_username": "test-username",
+				"exp":                time.Now().Add(-time.Hour).Unix(),
+			},
+			expectedError: false,
+			expectedAzp:   "test-client-id",
+			expectedUser:  "test-username",
+			expectedExp:   time.Now().Add(-time.Hour),
+		},
+		{
+			name: "token with future expiration",
+			tokenClaims: jwt.MapClaims{
+				"azp":                "test-client-id",
+				"preferred_username": "test-username",
+				"exp":                time.Now().Add(100 * time.Hour).Unix(),
+			},
+			expectedError: false,
+			expectedAzp:   "test-client-id",
+			expectedUser:  "test-username",
+			expectedExp:   time.Now().Add(100 * time.Hour),
+		},
+		{
+			name: "token with additional claims",
+			tokenClaims: jwt.MapClaims{
+				"azp":                "test-client-id",
+				"preferred_username": "test-username",
+				"exp":                time.Now().Add(time.Hour).Unix(),
+				"extra_claim":        "extra_value",
+			},
+			expectedError: false,
+			expectedAzp:   "test-client-id",
+			expectedUser:  "test-username",
+			expectedExp:   time.Now().Add(time.Hour),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tokenString string
+			var err error
+			tokenString = "invalid-token"
+			if tt.tokenClaims != nil {
+				token := jwt.NewWithClaims(jwt.SigningMethodHS256, tt.tokenClaims)
+				tokenString, err = token.SignedString([]byte("secret"))
+				assert.NoError(t, err)
+			}
+
+			clientId, username, exp, err := ExtractClaims(tokenString)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedAzp, clientId)
+				assert.Equal(t, tt.expectedUser, username)
+				if tt.expectedExp.IsZero() {
+					assert.Equal(t, tt.expectedExp, exp)
+				} else {
+					assert.WithinDuration(t, tt.expectedExp, exp, time.Minute)
+				}
+			}
+		})
+	}
+}

--- a/internal/auth/vault.go
+++ b/internal/auth/vault.go
@@ -20,16 +20,7 @@ const (
 	vaultSecretBaseURL = `/v1/secret/data/` // #nosec
 	m2mVaultClient     = "co-manager-m2m-client-secret"
 	VaultServer        = "http://vault.orch-platform.svc.cluster.local:8200"
-	// vaultServer := "http://localhost:8200" // for local testing
-	ServiceAccount = "cluster-manager"
-	// note: it was necessary to ensure that the Vault role configuration matches the service account and namespace being used.
-	// I have to adjust the Vault role configuration to include the cluster-manager service account (used for CM)
-	// $ vault write auth/kubernetes/role/cluster-manager \
-	// bound_service_account_names="cluster-manager" \
-	// bound_service_account_namespaces="orch-cluster" \
-	// policies="orch-svc" \
-	// ttl="1h"
-	// TODO: need to check if this can be done in the Job script when role is created in the vault server
+	ServiceAccount     = "cluster-manager"
 )
 
 type VaultAuth interface {
@@ -68,7 +59,6 @@ func (v *vaultAuth) getVaultToken(ctx context.Context) (string, error) {
 	}
 
 	tokenData, err := os.ReadFile(vaultK8STokenFile)
-	//	tokenData := []byte(vaultK8STokenFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to read Kubernetes token file: %w", err)
 	}

--- a/internal/auth/vault.go
+++ b/internal/auth/vault.go
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+const (
+	vaultK8STokenFile  = `/var/run/secrets/kubernetes.io/serviceaccount/token` // #nosec G101
+	vaultK8SLoginURL   = `/v1/auth/kubernetes/login`
+	vaultSecretBaseURL = `/v1/secret/data/` // #nosec
+	m2mVaultClient     = "co-manager-m2m-client-secret"
+	VaultServer        = "http://vault.orch-platform.svc.cluster.local:8200"
+	// vaultServer := "http://localhost:8200" // for local testing
+	ServiceAccount = "cluster-manager"
+	// note: it was necessary to ensure that the Vault role configuration matches the service account and namespace being used.
+	// I have to adjust the Vault role configuration to include the cluster-manager service account (used for CM)
+	// $ vault write auth/kubernetes/role/cluster-manager \
+	// bound_service_account_names="cluster-manager" \
+	// bound_service_account_namespaces="orch-cluster" \
+	// policies="orch-svc" \
+	// ttl="1h"
+	// TODO: need to check if this can be done in the Job script when role is created in the vault server
+)
+
+type VaultAuth interface {
+	GetClientCredentials(ctx context.Context) (string, string, error)
+}
+
+type vaultAuth struct {
+	vaultServer    string
+	serviceAccount string
+	httpClient     *http.Client
+	vaultToken     string
+	mu             sync.Mutex
+}
+
+func NewVaultAuth(vaultServer string, serviceAccount string) (VaultAuth, error) {
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	return &vaultAuth{
+		httpClient:     client,
+		vaultServer:    vaultServer,
+		serviceAccount: serviceAccount,
+	}, nil
+}
+
+func (v *vaultAuth) httpsVaultURL(path string) string {
+	return v.vaultServer + path
+}
+
+func (v *vaultAuth) getVaultToken(ctx context.Context) (string, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if v.vaultToken != "" {
+		return v.vaultToken, nil
+	}
+
+	tokenData, err := os.ReadFile(vaultK8STokenFile)
+	//	tokenData := []byte(vaultK8STokenFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to read Kubernetes token file: %w", err)
+	}
+
+	loginReq := struct {
+		JWT  string `json:"jwt"`
+		Role string `json:"role"`
+	}{
+		JWT:  string(tokenData),
+		Role: v.serviceAccount,
+	}
+
+	reqBody, err := json.Marshal(loginReq)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal login request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.httpsVaultURL(vaultK8SLoginURL), bytes.NewReader(reqBody))
+	if err != nil {
+		return "", fmt.Errorf("failed to create login request: %w", err)
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to perform login request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("vault login request failed with status code %d", resp.StatusCode)
+	}
+
+	var loginResp struct {
+		Auth struct {
+			ClientToken string `json:"client_token"`
+		} `json:"auth"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&loginResp); err != nil {
+		return "", fmt.Errorf("failed to decode login response: %w", err)
+	}
+
+	if loginResp.Auth.ClientToken == "" {
+		return "", fmt.Errorf("vault login response did not contain a client token")
+	}
+
+	v.vaultToken = loginResp.Auth.ClientToken
+	return v.vaultToken, nil
+}
+
+func (v *vaultAuth) GetClientCredentials(ctx context.Context) (string, string, error) {
+	vaultToken, err := v.getVaultToken(ctx)
+	if err != nil {
+		return "", "", err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.httpsVaultURL(vaultSecretBaseURL+m2mVaultClient), nil)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create request to fetch client credentials: %w", err)
+	}
+	req.Header.Add("X-Vault-Token", vaultToken)
+
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to fetch client credentials: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("failed to fetch client credentials, status code %d", resp.StatusCode)
+	}
+
+	var secretResp struct {
+		Data struct {
+			Data struct {
+				ClientID     string `json:"client_id"`
+				ClientSecret string `json:"client_secret"`
+			} `json:"data"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&secretResp); err != nil {
+		return "", "", fmt.Errorf("failed to decode client credentials response: %w", err)
+	}
+
+	return secretResp.Data.Data.ClientID, secretResp.Data.Data.ClientSecret, nil
+}

--- a/internal/inventory/inventory_test/grpc_test.go
+++ b/internal/inventory/inventory_test/grpc_test.go
@@ -121,7 +121,7 @@ func TestGetHostTrustedCompute(t *testing.T) {
 			name: "error getting host",
 			mock: func() {
 				mockClient.EXPECT().GetHostByUUID(mock.Anything, mock.Anything, mock.Anything).Return(nil, assert.AnError).Once()
-				mockClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(&inventoryv1.GetResourceResponse{}, assert.AnError).Once()				
+				mockClient.EXPECT().Get(mock.Anything, mock.Anything, mock.Anything).Return(&inventoryv1.GetResourceResponse{}, assert.AnError).Once()
 			},
 			expectedErr: assert.AnError,
 		},

--- a/internal/rest/getv2clustersnamekubeconfig.go
+++ b/internal/rest/getv2clustersnamekubeconfig.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/open-edge-platform/cluster-manager/v2/internal/auth"
 	"github.com/open-edge-platform/cluster-manager/v2/internal/core"
@@ -19,6 +20,7 @@ import (
 )
 
 var updateKubeconfigWithTokenFunc = updateKubeconfigWithToken
+var tokenRenewalFunc = tokenRenewal
 
 // (GET /v2/clusters/{name}/kubeconfigs)
 func (s *Server) GetV2ClustersNameKubeconfigs(ctx context.Context, request api.GetV2ClustersNameKubeconfigsRequestObject) (api.GetV2ClustersNameKubeconfigsResponseObject, error) {
@@ -26,6 +28,7 @@ func (s *Server) GetV2ClustersNameKubeconfigs(ctx context.Context, request api.G
 
 	authHeader := request.Params.Authorization
 	if !strings.HasPrefix(authHeader, auth.BearerPrefix) {
+		slog.Error("invalid Authorization header", "authHeader", authHeader)
 		return api.GetV2ClustersNameKubeconfigs401JSONResponse{
 			N401UnauthorizedJSONResponse: api.N401UnauthorizedJSONResponse{
 				Message: ptr("Unauthorized: invalid Authorization header"),
@@ -109,6 +112,10 @@ func (s *Server) getClusterKubeconfig(ctx context.Context, namespace, clusterNam
 
 func updateKubeconfigWithToken(kubeconfig kubeconfigParameters, namespace, clusterName, authHeader string) (string, error) {
 	token := auth.GetAccessToken(authHeader)
+	newAccessToken, err := tokenRenewalFunc(token)
+	if err != nil {
+		return "", err
+	}
 	caData, domain, userName := kubeconfig.serverCA, kubeconfig.clusterDomain, kubeconfig.userName
 
 	config, err := unmarshalKubeconfig(kubeconfig.kubeConfigDecode)
@@ -131,7 +138,7 @@ func updateKubeconfigWithToken(kubeconfig kubeconfigParameters, namespace, clust
 	serverAddress := fmt.Sprintf("https://connect-gateway.%s:443%s%s", domain, middleUrl, endSegment)
 	slog.Debug("serverAddress", "decoded", serverAddress)
 
-	updateKubeconfigFields(config, clusterName+"-"+userName, clusterName, serverAddress, caData, token)
+	updateKubeconfigFields(config, clusterName+"-"+userName, clusterName, serverAddress, caData, newAccessToken)
 
 	updatedKubeconfig, err := yaml.Marshal(config)
 	if err != nil {
@@ -226,6 +233,30 @@ func updateKubeconfigFields(config map[string]interface{}, user, clusterName, se
 			},
 		},
 	}
+}
+
+func tokenRenewal(accessToken string) (string, error) {
+	keycloak := "" // "http://platform-keycloak.orch-platform.svc/realms/master"// s.config.OidcUrl
+
+	_, _, expireTime, err := auth.ExtractClaims(accessToken)
+	if err != nil {
+		return "", fmt.Errorf("failed to extract claims: %w", err)
+	}
+
+	timeRemaining := time.Until(expireTime)
+
+	if timeRemaining > 0 {
+		tokenResponse, err := auth.JwtToken(keycloak, accessToken)
+		if err != nil {
+			return "", err
+		}
+		slog.Debug("token renewed", "renewedToken", tokenResponse.AccessToken) // remove
+
+		return tokenResponse.AccessToken, nil
+	}
+	slog.Debug("token not renewed", "timeRemaining", timeRemaining)
+
+	return accessToken, nil
 }
 
 type kubeConfigData struct {

--- a/internal/rest/getv2clustersnamekubeconfig_test.go
+++ b/internal/rest/getv2clustersnamekubeconfig_test.go
@@ -466,6 +466,14 @@ func TestUpdateKubeconfigWithToken(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Only mock token renewal for valid tokens (the first test)
+			// Let invalid tokens fail naturally for testing error handling
+			var restoreTokenRenewal func()
+			if tt.name == "successful update" {
+				restoreTokenRenewal = mockTokenRenewal(tt.token)
+				defer restoreTokenRenewal()
+			}
+			
 			updatedConfig, err := updateKubeconfigWithToken(tt.kubeconfig, tt.activeProjectID, tt.clusterName, tt.token)
 
 			if tt.expectedError != "" {

--- a/internal/rest/getv2clustersnamekubeconfig_test.go
+++ b/internal/rest/getv2clustersnamekubeconfig_test.go
@@ -543,7 +543,7 @@ func TestKubeconfigTTLBehavior(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Skip("TODO: Test will be implemented after TTL configuration is added")
+			t.Skip("TODO: Requires TTL configuration structure to be implemented")
 		})
 	}
 }
@@ -595,7 +595,7 @@ func TestTokenRenewalWithVaultAndKeycloak(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Skip("TODO: Test will be implemented after full M2M token renewal flow is implemented")
+			t.Skip("TODO: Requires complete TTL configuration and deployment setup")
 		})
 	}
 }
@@ -603,5 +603,5 @@ func TestTokenRenewalWithVaultAndKeycloak(t *testing.T) {
 // TestKubeconfigEndToEndWithTTL tests the complete kubeconfig retrieval with TTL
 // This test will fail initially until the full feature is implemented
 func TestKubeconfigEndToEndWithTTL(t *testing.T) {
-	t.Skip("TODO: Test will be implemented after complete TTL feature implementation")
+	t.Skip("TODO: Requires complete TTL configuration and deployment setup")
 }

--- a/internal/rest/getv2clustersnamekubeconfig_test.go
+++ b/internal/rest/getv2clustersnamekubeconfig_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/open-edge-platform/cluster-manager/v2/internal/config"
 	"github.com/open-edge-platform/cluster-manager/v2/internal/core"
@@ -480,4 +481,119 @@ func TestUpdateKubeconfigWithToken(t *testing.T) {
 
 func TestTokenRenewal(t *testing.T) {
 	// to implement
+}
+
+// TestKubeconfigTTLBehavior tests TTL behavior in kubeconfig generation
+// This test will fail initially until we implement TTL configuration
+func TestKubeconfigTTLBehavior(t *testing.T) {
+	tests := []struct {
+		name               string
+		disableCustomTTL   bool
+		kubeconfigTTL      time.Duration
+		tokenNeedsRenewal  bool
+		expectedError      bool
+		expectedTTL        time.Duration
+		tolerance          time.Duration
+	}{
+		{
+			name:              "custom TTL enabled - 2 hours",
+			disableCustomTTL:  false,  // false = enable custom TTL
+			kubeconfigTTL:     2 * time.Hour,
+			tokenNeedsRenewal: true,
+			expectedError:     false,
+			expectedTTL:       2 * time.Hour,
+			tolerance:         1 * time.Minute,
+		},
+		{
+			name:              "custom TTL enabled - 24 hours",
+			disableCustomTTL:  false,  // false = enable custom TTL
+			kubeconfigTTL:     24 * time.Hour,
+			tokenNeedsRenewal: true,
+			expectedError:     false,
+			expectedTTL:       24 * time.Hour,
+			tolerance:         1 * time.Minute,
+		},
+		{
+			name:              "custom TTL disabled - use default",
+			disableCustomTTL:  true,   // true = disable custom TTL
+			kubeconfigTTL:     12 * time.Hour,  // Should be ignored
+			tokenNeedsRenewal: true,
+			expectedError:     false,
+			expectedTTL:       1 * time.Hour,   // Keycloak default
+			tolerance:         5 * time.Minute,
+		},
+		{
+			name:              "token doesn't need renewal",
+			disableCustomTTL:  false,  // false = enable custom TTL
+			kubeconfigTTL:     6 * time.Hour,
+			tokenNeedsRenewal: false,
+			expectedError:     false,
+			expectedTTL:       0, // Original token TTL, not tested here
+			tolerance:         1 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Skip("TODO: Test will be implemented after TTL configuration is added")
+		})
+	}
+}
+
+// TestTokenRenewalWithVaultAndKeycloak tests the complete token renewal flow
+// This test will fail initially until we implement the full M2M flow
+func TestTokenRenewalWithVaultAndKeycloak(t *testing.T) {
+	tests := []struct {
+		name              string
+		originalTokenTTL  time.Duration
+		vaultClientID     string
+		vaultClientSecret string
+		userRoles         []string
+		requestedTTL      *time.Duration
+		vaultShouldFail   bool
+		expectedError     bool
+	}{
+		{
+			name:              "successful token renewal with vault credentials",
+			originalTokenTTL:  30 * time.Minute, // Needs renewal
+			vaultClientID:     "co-manager-m2m-client",
+			vaultClientSecret: "test-secret",
+			userRoles:         []string{"admin", "cluster-reader"},
+			requestedTTL:      &[]time.Duration{4 * time.Hour}[0],
+			vaultShouldFail:   false,
+			expectedError:     false,
+		},
+		{
+			name:              "vault failure during credential retrieval",
+			originalTokenTTL:  30 * time.Minute,
+			vaultClientID:     "",
+			vaultClientSecret: "",
+			userRoles:         []string{"user"},
+			requestedTTL:      &[]time.Duration{2 * time.Hour}[0],
+			vaultShouldFail:   true,
+			expectedError:     true,
+		},
+		{
+			name:              "token doesn't need renewal",
+			originalTokenTTL:  2 * time.Hour, // Still valid
+			vaultClientID:     "co-manager-m2m-client",
+			vaultClientSecret: "test-secret",
+			userRoles:         []string{"user"},
+			requestedTTL:      &[]time.Duration{6 * time.Hour}[0],
+			vaultShouldFail:   false,
+			expectedError:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Skip("TODO: Test will be implemented after full M2M token renewal flow is implemented")
+		})
+	}
+}
+
+// TestKubeconfigEndToEndWithTTL tests the complete kubeconfig retrieval with TTL
+// This test will fail initially until the full feature is implemented
+func TestKubeconfigEndToEndWithTTL(t *testing.T) {
+	t.Skip("TODO: Test will be implemented after complete TTL feature implementation")
 }

--- a/internal/rest/getv2clustersnamekubeconfig_test.go
+++ b/internal/rest/getv2clustersnamekubeconfig_test.go
@@ -473,7 +473,7 @@ func TestUpdateKubeconfigWithToken(t *testing.T) {
 				restoreTokenRenewal = mockTokenRenewal(tt.token)
 				defer restoreTokenRenewal()
 			}
-			
+
 			updatedConfig, err := updateKubeconfigWithToken(tt.kubeconfig, tt.activeProjectID, tt.clusterName, tt.token)
 
 			if tt.expectedError != "" {
@@ -495,17 +495,17 @@ func TestTokenRenewal(t *testing.T) {
 // This test will fail initially until we implement TTL configuration
 func TestKubeconfigTTLBehavior(t *testing.T) {
 	tests := []struct {
-		name               string
-		disableCustomTTL   bool
-		kubeconfigTTL      time.Duration
-		tokenNeedsRenewal  bool
-		expectedError      bool
-		expectedTTL        time.Duration
-		tolerance          time.Duration
+		name              string
+		disableCustomTTL  bool
+		kubeconfigTTL     time.Duration
+		tokenNeedsRenewal bool
+		expectedError     bool
+		expectedTTL       time.Duration
+		tolerance         time.Duration
 	}{
 		{
 			name:              "custom TTL enabled - 2 hours",
-			disableCustomTTL:  false,  // false = enable custom TTL
+			disableCustomTTL:  false, // false = enable custom TTL
 			kubeconfigTTL:     2 * time.Hour,
 			tokenNeedsRenewal: true,
 			expectedError:     false,
@@ -514,7 +514,7 @@ func TestKubeconfigTTLBehavior(t *testing.T) {
 		},
 		{
 			name:              "custom TTL enabled - 24 hours",
-			disableCustomTTL:  false,  // false = enable custom TTL
+			disableCustomTTL:  false, // false = enable custom TTL
 			kubeconfigTTL:     24 * time.Hour,
 			tokenNeedsRenewal: true,
 			expectedError:     false,
@@ -523,16 +523,16 @@ func TestKubeconfigTTLBehavior(t *testing.T) {
 		},
 		{
 			name:              "custom TTL disabled - use default",
-			disableCustomTTL:  true,   // true = disable custom TTL
-			kubeconfigTTL:     12 * time.Hour,  // Should be ignored
+			disableCustomTTL:  true,           // true = disable custom TTL
+			kubeconfigTTL:     12 * time.Hour, // Should be ignored
 			tokenNeedsRenewal: true,
 			expectedError:     false,
-			expectedTTL:       1 * time.Hour,   // Keycloak default
+			expectedTTL:       1 * time.Hour, // Keycloak default
 			tolerance:         5 * time.Minute,
 		},
 		{
 			name:              "token doesn't need renewal",
-			disableCustomTTL:  false,  // false = enable custom TTL
+			disableCustomTTL:  false, // false = enable custom TTL
 			kubeconfigTTL:     6 * time.Hour,
 			tokenNeedsRenewal: false,
 			expectedError:     false,

--- a/test/helpers/auth_mocks.go
+++ b/test/helpers/auth_mocks.go
@@ -116,7 +116,10 @@ func (m *MockKeycloakServer) handleTokenRequest(w http.ResponseWriter, r *http.R
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
 }
 
 func (m *MockKeycloakServer) generateMockJWT(ttl time.Duration) string {
@@ -184,7 +187,7 @@ func ValidateKubeconfigToken(kubeconfigYAML string, expectedTTL time.Duration, t
 	// Extract token from kubeconfig YAML
 	lines := strings.Split(kubeconfigYAML, "\n")
 	var token string
-	
+
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "token:") {
@@ -210,7 +213,7 @@ func ValidateKubeconfigToken(kubeconfigYAML string, expectedTTL time.Duration, t
 	}
 
 	if diff > tolerance {
-		return fmt.Errorf("token TTL %v differs from expected %v by more than tolerance %v", 
+		return fmt.Errorf("token TTL %v differs from expected %v by more than tolerance %v",
 			actualTTL, expectedTTL, tolerance)
 	}
 

--- a/test/helpers/auth_mocks.go
+++ b/test/helpers/auth_mocks.go
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+package helpers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/open-edge-platform/cluster-manager/v2/internal/auth"
+)
+
+// MockVaultAuth implements VaultAuth interface for testing
+type MockVaultAuth struct {
+	ClientID     string
+	ClientSecret string
+	ShouldFail   bool
+	FailMessage  string
+}
+
+func NewMockVaultAuth(clientID, clientSecret string) *MockVaultAuth {
+	return &MockVaultAuth{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		ShouldFail:   false,
+	}
+}
+
+func (m *MockVaultAuth) GetClientCredentials(ctx context.Context) (string, string, error) {
+	if m.ShouldFail {
+		return "", "", fmt.Errorf("mock vault error: %s", m.FailMessage)
+	}
+	return m.ClientID, m.ClientSecret, nil
+}
+
+func (m *MockVaultAuth) SetFailure(shouldFail bool, message string) {
+	m.ShouldFail = shouldFail
+	m.FailMessage = message
+}
+
+// MockKeycloakServer provides a mock Keycloak server for testing
+type MockKeycloakServer struct {
+	Server    *httptest.Server
+	TokenTTL  time.Duration
+	UserRoles []string
+}
+
+func NewMockKeycloakServer() *MockKeycloakServer {
+	mock := &MockKeycloakServer{
+		TokenTTL:  1 * time.Hour, // Default TTL
+		UserRoles: []string{"default-role"},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/protocol/openid-connect/token", mock.handleTokenRequest)
+	mock.Server = httptest.NewServer(mux)
+
+	return mock
+}
+
+func (m *MockKeycloakServer) Close() {
+	if m.Server != nil {
+		m.Server.Close()
+	}
+}
+
+func (m *MockKeycloakServer) URL() string {
+	return m.Server.URL
+}
+
+func (m *MockKeycloakServer) SetTokenTTL(ttl time.Duration) {
+	m.TokenTTL = ttl
+}
+
+func (m *MockKeycloakServer) SetUserRoles(roles []string) {
+	m.UserRoles = roles
+}
+
+func (m *MockKeycloakServer) handleTokenRequest(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	err := r.ParseForm()
+	if err != nil {
+		http.Error(w, "Invalid form data", http.StatusBadRequest)
+		return
+	}
+
+	grantType := r.FormValue("grant_type")
+	if grantType != "client_credentials" && grantType != "password" {
+		http.Error(w, "Unsupported grant type", http.StatusBadRequest)
+		return
+	}
+
+	// Extract TTL from request if provided
+	requestedTTL := m.TokenTTL
+	if ttlStr := r.FormValue("expires_in"); ttlStr != "" {
+		if ttlSeconds, err := time.ParseDuration(ttlStr + "s"); err == nil {
+			requestedTTL = ttlSeconds
+		}
+	}
+
+	// Generate a mock JWT token with the requested TTL
+	token := m.generateMockJWT(requestedTTL)
+
+	response := auth.TokenResponse{
+		AccessToken:  token,
+		RefreshToken: "mock-refresh-token",
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+func (m *MockKeycloakServer) generateMockJWT(ttl time.Duration) string {
+	now := time.Now()
+	exp := now.Add(ttl)
+
+	claims := jwt.MapClaims{
+		"azp":                "test-client",
+		"preferred_username": "test-user",
+		"exp":                exp.Unix(),
+		"iat":                now.Unix(),
+		"realm_access": map[string]interface{}{
+			"roles": m.UserRoles,
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, _ := token.SignedString([]byte("test-secret"))
+	return tokenString
+}
+
+// Helper functions for testing
+
+// CreateTestJWT creates a JWT token for testing with specified expiration and roles
+func CreateTestJWT(exp time.Time, roles []string) string {
+	claims := jwt.MapClaims{
+		"azp":                "test-client",
+		"preferred_username": "test-user",
+		"exp":                exp.Unix(),
+		"iat":                time.Now().Unix(),
+		"realm_access": map[string]interface{}{
+			"roles": roles,
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, _ := token.SignedString([]byte("test-secret"))
+	return tokenString
+}
+
+// ExtractTokenTTL extracts the TTL from a JWT token for testing
+func ExtractTokenTTL(tokenString string) (time.Duration, error) {
+	token, _, err := new(jwt.Parser).ParseUnverified(tokenString, jwt.MapClaims{})
+	if err != nil {
+		return 0, err
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return 0, fmt.Errorf("failed to extract claims")
+	}
+
+	exp, ok := claims["exp"].(float64)
+	if !ok {
+		return 0, fmt.Errorf("invalid or missing exp claim")
+	}
+
+	expTime := time.Unix(int64(exp), 0)
+	ttl := time.Until(expTime)
+	return ttl, nil
+}
+
+// ValidateKubeconfigToken validates that a kubeconfig contains a token with expected TTL
+func ValidateKubeconfigToken(kubeconfigYAML string, expectedTTL time.Duration, tolerance time.Duration) error {
+	// Extract token from kubeconfig YAML
+	lines := strings.Split(kubeconfigYAML, "\n")
+	var token string
+	
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "token:") {
+			token = strings.TrimSpace(strings.TrimPrefix(line, "token:"))
+			break
+		}
+	}
+
+	if token == "" {
+		return fmt.Errorf("no token found in kubeconfig")
+	}
+
+	// Extract TTL from token
+	actualTTL, err := ExtractTokenTTL(token)
+	if err != nil {
+		return fmt.Errorf("failed to extract TTL from token: %w", err)
+	}
+
+	// Check if TTL is within tolerance
+	diff := actualTTL - expectedTTL
+	if diff < 0 {
+		diff = -diff
+	}
+
+	if diff > tolerance {
+		return fmt.Errorf("token TTL %v differs from expected %v by more than tolerance %v", 
+			actualTTL, expectedTTL, tolerance)
+	}
+
+	return nil
+}

--- a/test/helpers/auth_mocks_test.go
+++ b/test/helpers/auth_mocks_test.go
@@ -1,0 +1,204 @@
+// SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+package helpers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockVaultAuth(t *testing.T) {
+	tests := []struct {
+		name           string
+		clientID       string
+		clientSecret   string
+		shouldFail     bool
+		failMessage    string
+		expectedError  bool
+	}{
+		{
+			name:          "successful credential retrieval",
+			clientID:      "test-client",
+			clientSecret:  "test-secret",
+			shouldFail:    false,
+			expectedError: false,
+		},
+		{
+			name:          "vault failure",
+			clientID:      "",
+			clientSecret:  "",
+			shouldFail:    true,
+			failMessage:   "vault connection failed",
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := NewMockVaultAuth(tt.clientID, tt.clientSecret)
+			if tt.shouldFail {
+				mock.SetFailure(true, tt.failMessage)
+			}
+
+			clientID, clientSecret, err := mock.GetClientCredentials(context.Background())
+
+			if tt.expectedError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.failMessage)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.clientID, clientID)
+				assert.Equal(t, tt.clientSecret, clientSecret)
+			}
+		})
+	}
+}
+
+func TestMockKeycloakServer(t *testing.T) {
+	server := NewMockKeycloakServer()
+	defer server.Close()
+
+	// Test default settings
+	assert.Equal(t, 1*time.Hour, server.TokenTTL)
+	assert.Equal(t, []string{"default-role"}, server.UserRoles)
+	assert.NotEmpty(t, server.URL())
+
+	// Test setting custom TTL
+	server.SetTokenTTL(2 * time.Hour)
+	assert.Equal(t, 2*time.Hour, server.TokenTTL)
+
+	// Test setting custom roles
+	customRoles := []string{"admin", "user", "cluster-reader"}
+	server.SetUserRoles(customRoles)
+	assert.Equal(t, customRoles, server.UserRoles)
+}
+
+func TestCreateTestJWT(t *testing.T) {
+	exp := time.Now().Add(2 * time.Hour)
+	roles := []string{"admin", "user"}
+
+	token := CreateTestJWT(exp, roles)
+	assert.NotEmpty(t, token)
+
+	// Test TTL extraction
+	ttl, err := ExtractTokenTTL(token)
+	require.NoError(t, err)
+	
+	// Should be close to 2 hours (within 1 minute tolerance)
+	expectedTTL := 2 * time.Hour
+	tolerance := 1 * time.Minute
+	diff := ttl - expectedTTL
+	if diff < 0 {
+		diff = -diff
+	}
+	assert.True(t, diff <= tolerance, "TTL %v should be within %v of expected %v", ttl, tolerance, expectedTTL)
+}
+
+func TestExtractTokenTTL(t *testing.T) {
+	tests := []struct {
+		name          string
+		expiration    time.Time
+		expectedError bool
+	}{
+		{
+			name:          "valid token with future expiration",
+			expiration:    time.Now().Add(1 * time.Hour),
+			expectedError: false,
+		},
+		{
+			name:          "valid token with different expiration",
+			expiration:    time.Now().Add(24 * time.Hour),
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := CreateTestJWT(tt.expiration, []string{"test-role"})
+			
+			ttl, err := ExtractTokenTTL(token)
+			
+			if tt.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				
+				// Calculate expected TTL
+				expectedTTL := time.Until(tt.expiration)
+				tolerance := 1 * time.Minute
+				
+				diff := ttl - expectedTTL
+				if diff < 0 {
+					diff = -diff
+				}
+				assert.True(t, diff <= tolerance, 
+					"Extracted TTL %v should be within %v of expected %v", 
+					ttl, tolerance, expectedTTL)
+			}
+		})
+	}
+}
+
+func TestValidateKubeconfigToken(t *testing.T) {
+	// Create a test kubeconfig with a token
+	exp := time.Now().Add(2 * time.Hour)
+	token := CreateTestJWT(exp, []string{"test-role"})
+	
+	kubeconfigYAML := `apiVersion: v1
+kind: Config
+users:
+- name: test-user
+  user:
+    token: ` + token + `
+`
+
+	tests := []struct {
+		name          string
+		expectedTTL   time.Duration
+		tolerance     time.Duration
+		expectedError bool
+	}{
+		{
+			name:          "valid TTL within tolerance",
+			expectedTTL:   2 * time.Hour,
+			tolerance:     5 * time.Minute,
+			expectedError: false,
+		},
+		{
+			name:          "TTL outside tolerance",
+			expectedTTL:   1 * time.Hour,  // Token has 2 hours
+			tolerance:     30 * time.Minute,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateKubeconfigToken(kubeconfigYAML, tt.expectedTTL, tt.tolerance)
+			
+			if tt.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateKubeconfigTokenWithoutToken(t *testing.T) {
+	kubeconfigYAML := `apiVersion: v1
+kind: Config
+users:
+- name: test-user
+  user:
+    username: test
+`
+
+	err := ValidateKubeconfigToken(kubeconfigYAML, 1*time.Hour, 1*time.Minute)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no token found in kubeconfig")
+}

--- a/test/helpers/auth_mocks_test.go
+++ b/test/helpers/auth_mocks_test.go
@@ -13,12 +13,12 @@ import (
 
 func TestMockVaultAuth(t *testing.T) {
 	tests := []struct {
-		name           string
-		clientID       string
-		clientSecret   string
-		shouldFail     bool
-		failMessage    string
-		expectedError  bool
+		name          string
+		clientID      string
+		clientSecret  string
+		shouldFail    bool
+		failMessage   string
+		expectedError bool
 	}{
 		{
 			name:          "successful credential retrieval",
@@ -87,7 +87,7 @@ func TestCreateTestJWT(t *testing.T) {
 	// Test TTL extraction
 	ttl, err := ExtractTokenTTL(token)
 	require.NoError(t, err)
-	
+
 	// Should be close to 2 hours (within 1 minute tolerance)
 	expectedTTL := 2 * time.Hour
 	tolerance := 1 * time.Minute
@@ -119,24 +119,24 @@ func TestExtractTokenTTL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			token := CreateTestJWT(tt.expiration, []string{"test-role"})
-			
+
 			ttl, err := ExtractTokenTTL(token)
-			
+
 			if tt.expectedError {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				
+
 				// Calculate expected TTL
 				expectedTTL := time.Until(tt.expiration)
 				tolerance := 1 * time.Minute
-				
+
 				diff := ttl - expectedTTL
 				if diff < 0 {
 					diff = -diff
 				}
-				assert.True(t, diff <= tolerance, 
-					"Extracted TTL %v should be within %v of expected %v", 
+				assert.True(t, diff <= tolerance,
+					"Extracted TTL %v should be within %v of expected %v",
 					ttl, tolerance, expectedTTL)
 			}
 		})
@@ -147,7 +147,7 @@ func TestValidateKubeconfigToken(t *testing.T) {
 	// Create a test kubeconfig with a token
 	exp := time.Now().Add(2 * time.Hour)
 	token := CreateTestJWT(exp, []string{"test-role"})
-	
+
 	kubeconfigYAML := `apiVersion: v1
 kind: Config
 users:
@@ -170,7 +170,7 @@ users:
 		},
 		{
 			name:          "TTL outside tolerance",
-			expectedTTL:   1 * time.Hour,  // Token has 2 hours
+			expectedTTL:   1 * time.Hour, // Token has 2 hours
 			tolerance:     30 * time.Minute,
 			expectedError: true,
 		},
@@ -179,7 +179,7 @@ users:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ValidateKubeconfigToken(kubeconfigYAML, tt.expectedTTL, tt.tolerance)
-			
+
 			if tt.expectedError {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
### Description

this PR implements machine-to-machine authentication with automatic token renewal for kubeconfig generation, enhancing security and user experience by ensuring kubeconfig files always contain valid, and support to configure TTL for tokens.

ITEP-23589
Fixes # (issue)

### Any Newly Introduced Dependencies

none

### How Has This Been Tested?

`make test`
`make run-service-test`
`make test` in the cluster-orchestrator components integration test (cluster-test repo)

Note: it was not tested with Orchestrator (EMF)

### Checklist:

- [x ] I agree to use the APACHE-2.0 license for my code changes
- [x ] I have not introduced any 3rd party dependency changes
- [x ] I have performed a self-review of my code