### PR TITLE
fix: remove trusted-compute-compatible from system labels

### DIFF
--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -20,7 +20,7 @@ const (
 )
 
 var (
-	systemPrefixes  = []string{PlatformPrefix, capiDomainLabelKey, capiTopologyLabelKey, PrometheusMetricsUrlLabelKey, TrustedComputeLabelKey}
+	systemPrefixes  = []string{PlatformPrefix, capiDomainLabelKey, capiTopologyLabelKey, PrometheusMetricsUrlLabelKey}
 	labelKeyRegex   = regexp.MustCompile(`^(([A-Za-z0-9][-A-Za-z0-9_.]{0,250})?[A-Za-z0-9]\/)?([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]$`)
 	labelValueRegex = regexp.MustCompile(`^([A-Za-z0-9][-A-Za-z0-9_.]{0,61})?[A-Za-z0-9]?$`)
 )

--- a/internal/labels/labels_test.go
+++ b/internal/labels/labels_test.go
@@ -29,11 +29,12 @@ func TestUserLabels(t *testing.T) {
 	}
 
 	want := map[string]string{
-		"clustername": "scale-0a9c889f-97a4-5a27-aa57-e82300a2b19c",
-		"cpumanager":  "true",
-		"test-app":    "enabled",
-		"tests":       "scale",
-		"default":     "true",
+		"clustername":                "scale-0a9c889f-97a4-5a27-aa57-e82300a2b19c",
+		"cpumanager":                 "true",
+		"test-app":                   "enabled",
+		"tests":                      "scale",
+		"default":                    "true",
+		"trusted-compute-compatible": "true",
 	}
 
 	got := labels.UserLabels(clusterLabels)
@@ -69,7 +70,6 @@ func TestSystemLabels(t *testing.T) {
 		"cluster.x-k8s.io/cluster-name":           "demo-cluster",
 		"edge-orchestrator.intel.com/users-label": "user-value",
 		"topology.cluster.x-k8s.io/owned":         "",
-		"trusted-compute-compatible":              "false",
 	}
 
 	got := labels.SystemLabels(clusterLabels)


### PR DESCRIPTION
### Description

TC compatible cluster label is missing in the cluster detail API response, resulting in UI to show incorrect value in cluster detail page.

Fixes # (issue)

https://jira.devtools.intel.com/browse/ITEP-78620

### Any Newly Introduced Dependencies

No

### How Has This Been Tested?

Tested with the latest EMF and Ubuntu 22.04 on XR-12.
<img width="1971" height="1095" alt="Screenshot 2025-10-03 at 2 16 05 PM" src="https://github.com/user-attachments/assets/0f43122c-cdbf-40a4-a972-9330e5eb6055" />

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code